### PR TITLE
Mobile messages horizontal scroll

### DIFF
--- a/app/components/AppLayout.tsx
+++ b/app/components/AppLayout.tsx
@@ -21,7 +21,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <div className="bg-gray-scale-2 dark:bg-gray-scale-1 h-dvh overflow-y-auto flex flex-col">
+    <div className="bg-gray-scale-2 dark:bg-gray-scale-1 h-dvh overflow-y-auto overflow-x-hidden flex flex-col">
       <ThemeSynchronizer />
       <Sidebar />
       {children}

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -258,7 +258,7 @@ export default function ChatInput({
       layoutId="chat-input-container"
       className={`z-50 backdrop-blur-sm flex flex-col subtle-shadow bg-gray-scale-1 dark:bg-gray-scale-2  border-gray-scale-4 border w-full ${
         style === "bottom"
-          ? `w-full max-w-2xl fixed bottom-0 md:border-b-0 md:pb-2 rounded-t-xl ${
+          ? `w-full max-w-2xl fixed bottom-0 left-0 right-0 mx-auto md:border-b-0 md:pb-2 rounded-t-xl ${
               isPWA ? "pb-10 md:pb-0" : ""
             }`
           : "max-w-2xl mt-10 rounded-xl"

--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -129,7 +129,7 @@ export default function Message({
         )}
 
       <Streamdown
-        className="text-gray-scale-12 whitespace-pre-wrap w-full"
+        className="text-gray-scale-12 whitespace-pre-wrap w-full break-words"
         components={{
           code: ({ children, className, ...props }) => (
             <CodeBlock className={className} {...props}>


### PR DESCRIPTION
Fixes unwanted horizontal scrolling on mobile by constraining layout, wrapping long text, and centering the chat input.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3916c8f-d891-496d-b0e4-c74e42883871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3916c8f-d891-496d-b0e4-c74e42883871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

