### PR TITLE
Add image attachments for worker prompts

### DIFF
--- a/app/factory/[factoryId]/worker-run-form.tsx
+++ b/app/factory/[factoryId]/worker-run-form.tsx
@@ -2,8 +2,18 @@
 
 import { faker } from "@faker-js/faker";
 import { id } from "@instantdb/react";
+import { ImageSquare, X } from "@phosphor-icons/react";
 import { useRouter } from "next/navigation";
-import { type FormEvent, type KeyboardEvent, useState } from "react";
+import {
+  type ChangeEvent,
+  type Dispatch,
+  type FormEvent,
+  type KeyboardEvent,
+  type RefObject,
+  type SetStateAction,
+  useRef,
+  useState,
+} from "react";
 import Button from "@/components/public/Button";
 import Card from "@/components/public/Card";
 import type { AppDb } from "@/lib/db.client";
@@ -19,6 +29,21 @@ export type WorkerRecord = {
   status: string;
   updatedAt?: string;
 };
+
+type ImageAttachment = {
+  file: File;
+  id: string;
+  previewUrl: string;
+};
+
+const maxImageAttachments = 5;
+const maxImageAttachmentBytes = 20 * 1024 * 1024;
+const supportedImageTypes = new Set([
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
 
 export function NewWorkerForm({ factoryId }: { factoryId: string }) {
   if (!db) {
@@ -37,8 +62,11 @@ function NewWorkerFormContent({
 }) {
   const router = useRouter();
   const { user } = instantDb.useAuth();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
   const [prompt, setPrompt] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -58,17 +86,27 @@ function NewWorkerFormContent({
     const workerId = id();
 
     setError(null);
-    setPrompt("");
-    router.push(`/factory/${factoryId}/workers/${workerId}`);
+    setIsSending(true);
 
-    triggerWorkerRun({
+    const startedWorkerId = await triggerWorkerRun({
+      attachments,
       factoryId,
       instantDb,
       prompt: trimmedPrompt,
+      userId: user.id,
       userRefreshToken: user.refresh_token,
       workerId,
       onError: setError,
     });
+
+    setIsSending(false);
+
+    if (startedWorkerId) {
+      cleanupAttachments(attachments);
+      setAttachments([]);
+      setPrompt("");
+      router.push(`/factory/${factoryId}/workers/${workerId}`);
+    }
   }
 
   return (
@@ -83,14 +121,36 @@ function NewWorkerFormContent({
           onKeyDown={submitTextareaOnEnter}
           rows={4}
         />
+        <ImageAttachmentTray
+          attachments={attachments}
+          disabled={isSending}
+          fileInputRef={fileInputRef}
+          onAdd={(event) =>
+            addImageAttachments({
+              currentAttachments: attachments,
+              event,
+              onError: setError,
+              setAttachments,
+            })
+          }
+          onRemove={(attachmentId) =>
+            setAttachments((current) =>
+              removeImageAttachment(current, attachmentId),
+            )
+          }
+        />
         {error ? <p>{error}</p> : null}
         <div className="flex flex-row items-center justify-between p-2">
           <div className="flex flex-row items-center gap-2">
             {/*<p className="text-sm text-grayscale-11">Create more</p>
             <Switch />*/}
           </div>
-          <Button type="submit" className="ml-auto">
-            Send
+          <Button type="submit" className="ml-auto" disabled={isSending}>
+            {isSending
+              ? attachments.length > 0
+                ? "Uploading..."
+                : "Sending..."
+              : "Send"}
           </Button>
         </div>
       </form>
@@ -98,24 +158,41 @@ function NewWorkerFormContent({
   );
 }
 
-export function WorkerPromptForm({ worker }: { worker: WorkerRecord }) {
+export function WorkerPromptForm({
+  factoryId,
+  worker,
+}: {
+  factoryId?: string;
+  worker: WorkerRecord;
+}) {
   if (!db) {
     return <p>InstantDB is not configured.</p>;
   }
 
-  return <WorkerPromptFormContent instantDb={db} worker={worker} />;
+  return (
+    <WorkerPromptFormContent
+      factoryId={factoryId}
+      instantDb={db}
+      worker={worker}
+    />
+  );
 }
 
 function WorkerPromptFormContent({
+  factoryId,
   instantDb,
   worker,
 }: {
+  factoryId?: string;
   instantDb: AppDb;
   worker: WorkerRecord;
 }) {
   const { user } = instantDb.useAuth();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
   const [prompt, setPrompt] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
   const [snapshotStatus, setSnapshotStatus] = useState<
     "error" | "idle" | "saving" | "saved"
   >("idle");
@@ -123,15 +200,24 @@ function WorkerPromptFormContent({
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
+    setIsSending(true);
+
     const workerId = await triggerWorkerRun({
+      attachments,
+      factoryId,
       instantDb,
       prompt,
+      userId: user?.id,
       userRefreshToken: user?.refresh_token,
       worker,
       onError: setError,
     });
 
+    setIsSending(false);
+
     if (workerId) {
+      cleanupAttachments(attachments);
+      setAttachments([]);
       setPrompt("");
     }
   }
@@ -198,6 +284,24 @@ function WorkerPromptFormContent({
           onKeyDown={submitTextareaOnEnter}
           rows={4}
         />
+        <ImageAttachmentTray
+          attachments={attachments}
+          disabled={isRetired || isSending}
+          fileInputRef={fileInputRef}
+          onAdd={(event) =>
+            addImageAttachments({
+              currentAttachments: attachments,
+              event,
+              onError: setError,
+              setAttachments,
+            })
+          }
+          onRemove={(attachmentId) =>
+            setAttachments((current) =>
+              removeImageAttachment(current, attachmentId),
+            )
+          }
+        />
         {error ? <p>{error}</p> : null}
         <div className="flex flex-row items-center justify-between p-2">
           <div className="flex flex-row items-center gap-2">
@@ -211,8 +315,18 @@ function WorkerPromptFormContent({
               {snapshotLabel}
             </Button>
           </div>
-          <Button type="submit" className="ml-auto" disabled={isRetired}>
-            {worker.status === "running" ? "Interrupt and send" : "Send"}
+          <Button
+            type="submit"
+            className="ml-auto"
+            disabled={isRetired || isSending}
+          >
+            {isSending
+              ? attachments.length > 0
+                ? "Uploading..."
+                : "Sending..."
+              : worker.status === "running"
+                ? "Interrupt and send"
+                : "Send"}
           </Button>
         </div>
       </form>
@@ -234,18 +348,22 @@ function submitTextareaOnEnter(event: KeyboardEvent<HTMLTextAreaElement>) {
 }
 
 async function triggerWorkerRun({
+  attachments = [],
   factoryId,
   instantDb,
   onError,
   prompt,
+  userId,
   userRefreshToken,
   worker,
   workerId: preGeneratedWorkerId,
 }: {
+  attachments?: ImageAttachment[];
   factoryId?: string;
   instantDb: AppDb;
   onError: (error: string | null) => void;
   prompt: string;
+  userId?: string;
   userRefreshToken?: string;
   worker?: WorkerRecord;
   workerId?: string;
@@ -265,6 +383,11 @@ async function triggerWorkerRun({
     return null;
   }
 
+  if (!userId) {
+    onError("You must be signed in to upload images.");
+    return null;
+  }
+
   const now = new Date().toISOString();
   const workerId = preGeneratedWorkerId ?? worker?.id ?? id();
   const eventId = id();
@@ -274,6 +397,14 @@ async function triggerWorkerRun({
   onError(null);
 
   try {
+    const attachmentFileIds = await uploadImageAttachments({
+      attachments,
+      eventId,
+      factoryId,
+      instantDb,
+      userId,
+      workerId,
+    });
     const transactions = [
       instantDb.tx.events[eventId].update({
         createdAt: now,
@@ -286,6 +417,11 @@ async function triggerWorkerRun({
       instantDb.tx.events[eventId].link({
         worker: workerId,
       }),
+      ...attachmentFileIds.map((attachmentFileId) =>
+        instantDb.tx.events[eventId].link({
+          attachments: attachmentFileId,
+        }),
+      ),
       instantDb.tx.workers[workerId].update({
         status: nextStatus,
         updatedAt: now,
@@ -341,4 +477,187 @@ async function triggerWorkerRun({
     );
     return null;
   }
+}
+
+function ImageAttachmentTray({
+  attachments,
+  disabled,
+  fileInputRef,
+  onAdd,
+  onRemove,
+}: {
+  attachments: ImageAttachment[];
+  disabled?: boolean;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  onAdd: (event: ChangeEvent<HTMLInputElement>) => void;
+  onRemove: (attachmentId: string) => void;
+}) {
+  return (
+    <div className="border-grayscale-3 border-t px-3 py-2">
+      {attachments.length > 0 ? (
+        <ul className="mb-2 flex flex-wrap gap-2">
+          {attachments.map((attachment) => (
+            <li
+              className="group relative size-16 overflow-hidden rounded-lg border border-grayscale-3 bg-grayscale-2"
+              key={attachment.id}
+            >
+              <div
+                aria-hidden="true"
+                className="size-full bg-cover bg-center"
+                style={{ backgroundImage: `url(${attachment.previewUrl})` }}
+              />
+              <button
+                aria-label={`Remove ${attachment.file.name}`}
+                className="absolute top-1 right-1 flex size-5 items-center justify-center rounded-full border border-grayscale-5 bg-white/90 text-grayscale-11 shadow-sm transition hover:bg-grayscale-1 hover:text-grayscale-12"
+                disabled={disabled}
+                onClick={() => onRemove(attachment.id)}
+                type="button"
+              >
+                <X size={12} weight="bold" aria-hidden="true" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <input
+        accept="image/png,image/jpeg,image/webp,image/gif"
+        className="sr-only"
+        disabled={disabled}
+        multiple
+        onChange={onAdd}
+        ref={fileInputRef}
+        type="file"
+      />
+      <Button
+        type="button"
+        variant="secondary"
+        disabled={disabled || attachments.length >= maxImageAttachments}
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <ImageSquare size={16} weight="bold" aria-hidden="true" />
+        {attachments.length > 0 ? "Add image" : "Attach image"}
+      </Button>
+    </div>
+  );
+}
+
+function addImageAttachments({
+  currentAttachments,
+  event,
+  onError,
+  setAttachments,
+}: {
+  currentAttachments: ImageAttachment[];
+  event: ChangeEvent<HTMLInputElement>;
+  onError: (error: string | null) => void;
+  setAttachments: Dispatch<SetStateAction<ImageAttachment[]>>;
+}) {
+  const selectedFiles = Array.from(event.target.files ?? []);
+  event.target.value = "";
+
+  if (selectedFiles.length === 0) {
+    return;
+  }
+
+  const remainingSlots = maxImageAttachments - currentAttachments.length;
+  const validAttachments: ImageAttachment[] = [];
+
+  for (const file of selectedFiles.slice(0, remainingSlots)) {
+    if (!supportedImageTypes.has(file.type)) {
+      onError("Attach PNG, JPEG, WebP, or GIF images.");
+      continue;
+    }
+
+    if (file.size > maxImageAttachmentBytes) {
+      onError("Images must be 20 MB or smaller.");
+      continue;
+    }
+
+    validAttachments.push({
+      file,
+      id: id(),
+      previewUrl: URL.createObjectURL(file),
+    });
+  }
+
+  if (selectedFiles.length > remainingSlots) {
+    onError(`Attach up to ${maxImageAttachments} images.`);
+  } else if (validAttachments.length > 0) {
+    onError(null);
+  }
+
+  if (validAttachments.length > 0) {
+    setAttachments((current) => [...current, ...validAttachments]);
+  }
+}
+
+function removeImageAttachment(
+  attachments: ImageAttachment[],
+  attachmentId: string,
+) {
+  const attachment = attachments.find((item) => item.id === attachmentId);
+
+  if (attachment) {
+    URL.revokeObjectURL(attachment.previewUrl);
+  }
+
+  return attachments.filter((item) => item.id !== attachmentId);
+}
+
+function cleanupAttachments(attachments: ImageAttachment[]) {
+  for (const attachment of attachments) {
+    URL.revokeObjectURL(attachment.previewUrl);
+  }
+}
+
+async function uploadImageAttachments({
+  attachments,
+  eventId,
+  factoryId,
+  instantDb,
+  userId,
+  workerId,
+}: {
+  attachments: ImageAttachment[];
+  eventId: string;
+  factoryId?: string;
+  instantDb: AppDb;
+  userId: string;
+  workerId: string;
+}) {
+  return Promise.all(
+    attachments.map(async (attachment) => {
+      const extension = getImageExtension(attachment.file);
+      const path = [
+        userId,
+        "factories",
+        factoryId ?? "existing-worker",
+        "workers",
+        workerId,
+        "events",
+        eventId,
+        `${attachment.id}.${extension}`,
+      ].join("/");
+      const response = await instantDb.storage.uploadFile(
+        path,
+        attachment.file,
+        {
+          contentDisposition: "inline",
+          contentType: attachment.file.type || "application/octet-stream",
+        },
+      );
+
+      return response.data.id;
+    }),
+  );
+}
+
+function getImageExtension(file: File) {
+  const extensionFromName = file.name.split(".").pop()?.toLowerCase();
+
+  if (extensionFromName && /^[a-z0-9]+$/.test(extensionFromName)) {
+    return extensionFromName;
+  }
+
+  return file.type.split("/")[1]?.replace(/\W/g, "") || "image";
 }

--- a/app/factory/[factoryId]/workers/[workerId]/page.tsx
+++ b/app/factory/[factoryId]/workers/[workerId]/page.tsx
@@ -46,7 +46,9 @@ function WorkerPageContent({ instantDb }: { instantDb: AppDb }) {
       ? {
           workers: {
             $: { where: { id: workerId } },
-            events: {},
+            events: {
+              attachments: {},
+            },
             factory: {},
             ports: {},
           },
@@ -116,11 +118,11 @@ function WorkerPageContent({ instantDb }: { instantDb: AppDb }) {
   return (
     <div className="flex h-dvh w-full flex-col">
       <header className="flex min-h-16 shrink-0 items-center justify-between gap-4 border-grayscale-3 border-b px-4">
-        <div className="min-w-0">
-          <h1 className="truncate font-semibold text-base text-grayscale-12">
+        <div className="flex min-w-0 items-center gap-2">
+          <h1 className="min-w-0 truncate font-semibold text-base text-grayscale-12">
             {workerTitle}
           </h1>
-          <p className="text-grayscale-10 text-xs capitalize">
+          <p className="shrink-0 text-grayscale-10 text-xs capitalize">
             {worker.status}
           </p>
         </div>
@@ -169,7 +171,7 @@ function WorkerPageContent({ instantDb }: { instantDb: AppDb }) {
       </div>
 
       <div className="w-full mt-auto mb-4">
-        <WorkerPromptForm worker={worker} />
+        <WorkerPromptForm factoryId={factoryId} worker={worker} />
       </div>
     </div>
   );

--- a/components/Event.tsx
+++ b/components/Event.tsx
@@ -10,6 +10,12 @@ import type schema from "@/instant.schema";
 
 export type EventRecord = InstaQLEntity<typeof schema, "events">;
 
+type EventAttachment = {
+  id: string;
+  path?: string;
+  url?: string;
+};
+
 type EventProps = {
   event: EventRecord;
   factoryId?: string;
@@ -35,6 +41,7 @@ type EventFeedItem =
     };
 
 type MessageEventProps = {
+  attachments?: EventAttachment[];
   label: string;
   message: string;
 };
@@ -81,8 +88,11 @@ export default function Event({
 
   if (event.type === "user_message") {
     const message = getUserPrompt(event.data);
+    const attachments = getEventAttachments(event);
 
-    return message ? <MessageEvent label="You" message={message} /> : null;
+    return message ? (
+      <MessageEvent attachments={attachments} label="You" message={message} />
+    ) : null;
   }
 
   if (event.type === "factory.mcp.connection.requested") {
@@ -102,7 +112,11 @@ export default function Event({
   return message ? <MessageEvent label="System" message={message} /> : null;
 }
 
-export function MessageEvent({ label, message }: MessageEventProps) {
+export function MessageEvent({
+  attachments = [],
+  label,
+  message,
+}: MessageEventProps) {
   return (
     <li>
       <motion.div
@@ -117,6 +131,25 @@ export function MessageEvent({ label, message }: MessageEventProps) {
         <div className="whitespace-pre-wrap text-sm text-grayscale-12">
           {message}
         </div>
+        {attachments.length > 0 ? (
+          <ul className="mt-2 flex flex-wrap gap-2">
+            {attachments.map((attachment) => (
+              <li
+                className="size-24 overflow-hidden rounded-lg border border-grayscale-3 bg-grayscale-2"
+                key={attachment.id}
+              >
+                {attachment.url ? (
+                  <div
+                    aria-label={attachment.path ?? "Attached image"}
+                    className="size-full bg-cover bg-center"
+                    role="img"
+                    style={{ backgroundImage: `url(${attachment.url})` }}
+                  />
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : null}
       </motion.div>
     </li>
   );
@@ -441,6 +474,25 @@ function getUserPrompt(data: unknown) {
   }
 
   return String(data.prompt ?? "");
+}
+
+function getEventAttachments(event: EventRecord) {
+  const attachments = "attachments" in event ? event.attachments : undefined;
+
+  if (!Array.isArray(attachments)) {
+    return [];
+  }
+
+  return attachments.filter(isEventAttachment);
+}
+
+function isEventAttachment(value: unknown): value is EventAttachment {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    (typeof value.url === "string" || value.url === undefined) &&
+    (typeof value.path === "string" || value.path === undefined)
+  );
 }
 
 function getCodexAgentMessageText(data: unknown) {

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -219,6 +219,18 @@ const _schema = i.schema({
         label: "events",
       },
     },
+    eventAttachments: {
+      forward: {
+        on: "events",
+        has: "many",
+        label: "attachments",
+      },
+      reverse: {
+        on: "$files",
+        has: "one",
+        label: "event",
+      },
+    },
     workerPorts: {
       forward: {
         on: "ports",

--- a/jobs/run-worker.ts
+++ b/jobs/run-worker.ts
@@ -2,11 +2,14 @@ import { id } from "@instantdb/admin";
 import { logger, metadata, task } from "@trigger.dev/sdk";
 import { getFactoryMcpGatewayUrl } from "@/lib/app-url";
 import {
+  cleanCommandOutput,
   createWorkerBox,
   ensureLatestCodexOnBox,
   getBox,
   getExecStreamChunkText,
   killWorkerPid,
+  runBoxCommand,
+  shellQuote,
   streamCodexExec,
   waitForWorkerPid,
 } from "@/lib/codex/box-auth";
@@ -41,10 +44,17 @@ type SecretRecord = {
 };
 
 type EventRecord = {
+  attachments?: AttachmentRecord[];
   data?: {
     prompt?: string;
   };
   id: string;
+};
+
+type AttachmentRecord = {
+  id: string;
+  path?: string;
+  url?: string;
 };
 
 type JsonValue =
@@ -205,6 +215,18 @@ export const runWorkerTask = task({
         sandboxId,
         workerId: worker.id,
       });
+      const imagePaths = await stageWorkerImageAttachments({
+        attachments: userMessageEvent?.attachments ?? [],
+        box,
+        eventId: payload.userMessageEventId,
+        workerId: worker.id,
+      });
+
+      logTaskStep("info", "Worker image attachments staged", {
+        attachmentCount: imagePaths.length,
+        sandboxId,
+        workerId: worker.id,
+      });
 
       await db.transact(
         db.tx.workers[worker.id].update({
@@ -228,6 +250,7 @@ export const runWorkerTask = task({
 
       const stream = await streamCodexExec({
         box,
+        imagePaths,
         mcpConfig,
         prompt,
         resume: Boolean(worker.sandboxId),
@@ -415,10 +438,90 @@ async function getUserMessageEvent(eventId: string) {
   const result = await db.query({
     events: {
       $: { where: { id: eventId } },
+      attachments: {},
     },
   });
 
   return result.events[0] as EventRecord | undefined;
+}
+
+async function stageWorkerImageAttachments({
+  attachments,
+  box,
+  eventId,
+  workerId,
+}: {
+  attachments: AttachmentRecord[];
+  box: Awaited<ReturnType<typeof getBox>>;
+  eventId: string;
+  workerId: string;
+}) {
+  const imageAttachments = attachments.filter(isImageAttachment);
+
+  if (imageAttachments.length === 0) {
+    return [];
+  }
+
+  const attachmentDir = `/workspace/home/.factory/workers/${workerId}/attachments/${eventId}`;
+  const stagedAttachments = imageAttachments.map((attachment, index) => ({
+    path: `${attachmentDir}/image-${index + 1}${getAttachmentExtension(attachment)}`,
+    url: attachment.url,
+  }));
+  const script = `
+const fs = require("node:fs/promises");
+const items = JSON.parse(process.argv[1]);
+
+async function main() {
+  for (const item of items) {
+    const response = await fetch(item.url);
+
+    if (!response.ok) {
+      throw new Error(\`Could not download attachment: \${response.status}\`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    await fs.writeFile(item.path, Buffer.from(arrayBuffer));
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+`.trim();
+  const result = await runBoxCommand(
+    box,
+    [
+      `mkdir -p ${shellQuote(attachmentDir)}`,
+      `node -e ${shellQuote(script)} ${shellQuote(JSON.stringify(stagedAttachments))}`,
+    ].join(" && "),
+    120_000,
+  );
+
+  if (!result.success) {
+    throw new Error(
+      `Could not stage image attachments: ${
+        cleanCommandOutput(result.output) || "No output"
+      }`,
+    );
+  }
+
+  return stagedAttachments.map((attachment) => attachment.path);
+}
+
+function isImageAttachment(attachment: AttachmentRecord) {
+  return (
+    typeof attachment.url === "string" &&
+    attachment.url.length > 0 &&
+    /\.(avif|gif|jpe?g|png|webp)$/i.test(attachment.path ?? attachment.url)
+  );
+}
+
+function getAttachmentExtension(attachment: AttachmentRecord) {
+  const source = attachment.path ?? attachment.url ?? "";
+  const match = source.match(/\.(avif|gif|jpe?g|png|webp)(?:[?#].*)?$/i);
+
+  return match ? `.${match[1].toLowerCase()}` : ".png";
 }
 
 async function persistCodexLine(workerId: string, line: string) {

--- a/lib/codex/box-auth.ts
+++ b/lib/codex/box-auth.ts
@@ -190,6 +190,7 @@ export async function restoreCodexHome(box: Box) {
 
 export async function streamCodexExec({
   box,
+  imagePaths,
   mcpConfig,
   prompt,
   resume,
@@ -198,6 +199,7 @@ export async function streamCodexExec({
   workerId,
 }: {
   box: Box;
+  imagePaths?: string[];
   mcpConfig?: {
     gatewayUrl: string;
     token: string;
@@ -210,6 +212,7 @@ export async function streamCodexExec({
 }) {
   return box.exec.stream(
     createCodexExecCommand({
+      imagePaths,
       mcpConfig,
       prompt,
       resume,
@@ -274,6 +277,7 @@ function createBoxCommand(command: string, timeoutMs?: number) {
 }
 
 function createCodexExecCommand({
+  imagePaths = [],
   mcpConfig,
   prompt,
   resume,
@@ -281,6 +285,7 @@ function createCodexExecCommand({
   sessionId,
   workerId,
 }: {
+  imagePaths?: string[];
   mcpConfig?: {
     gatewayUrl: string;
     token: string;
@@ -312,12 +317,16 @@ function createCodexExecCommand({
         ),
       ].join(" ")
     : "";
+  const imageArgs = imagePaths
+    .map((imagePath) => `--image ${shellQuote(imagePath)}`)
+    .join(" ");
   const codexCommand = resume
     ? [
         "codex exec resume",
         sessionId ? shellQuote(sessionId) : "--last",
         "--model",
         shellQuote(codexModel),
+        imageArgs,
         mcpArgs,
         "--dangerously-bypass-approvals-and-sandbox",
         "--skip-git-repo-check",
@@ -328,6 +337,7 @@ function createCodexExecCommand({
         "codex exec",
         "--model",
         shellQuote(codexModel),
+        imageArgs,
         mcpArgs,
         "--dangerously-bypass-approvals-and-sandbox",
         "--skip-git-repo-check",


### PR DESCRIPTION
## Summary
- add InstantDB file links for event attachments and render prompt image thumbnails
- upload image attachments from the worker prompt forms with local previews and send-state feedback
- stage uploaded images into the worker sandbox and pass them to Codex with --image

## Verification
- npm run check
- npx tsc --noEmit
- npm run build