### PR TITLE
Add settings sidebar navigation

### DIFF
--- a/app/factory/[factoryId]/layout.tsx
+++ b/app/factory/[factoryId]/layout.tsx
@@ -2,13 +2,11 @@
 
 import NumberFlow from "@number-flow/react";
 import {
+  ChatsTeardropIcon,
   CircleNotchIcon,
   FadersIcon,
-  FilesIcon,
   GearSixIcon,
   ListIcon,
-  LockKeyIcon,
-  PlugsConnectedIcon,
   PlusIcon,
   SignOutIcon,
   UserCircleIcon,
@@ -246,23 +244,22 @@ function FactoryToolsRail({
 }) {
   const links = [
     {
-      href: `/factory/${factoryId}/secrets`,
-      icon: <LockKeyIcon aria-hidden="true" size={17} weight="bold" />,
-      label: "Secrets",
-    },
-    {
-      href: `/factory/${factoryId}/skills`,
-      icon: <FilesIcon aria-hidden="true" size={17} weight="bold" />,
-      label: "Skills",
-    },
-    {
-      href: `/factory/${factoryId}/mcp`,
-      icon: <PlugsConnectedIcon aria-hidden="true" size={17} weight="bold" />,
-      label: "MCP",
+      href: `/factory/${factoryId}`,
+      icon: <ChatsTeardropIcon aria-hidden="true" size={17} weight="bold" />,
+      isActive:
+        currentPathname === `/factory/${factoryId}` ||
+        currentPathname.startsWith(`/factory/${factoryId}/workers/`),
+      label: "Workers",
     },
     {
       href: `/factory/${factoryId}/settings`,
       icon: <FadersIcon aria-hidden="true" size={17} weight="bold" />,
+      isActive: [
+        `/factory/${factoryId}/settings`,
+        `/factory/${factoryId}/secrets`,
+        `/factory/${factoryId}/skills`,
+        `/factory/${factoryId}/mcp`,
+      ].includes(currentPathname),
       label: "Settings",
     },
   ];
@@ -278,9 +275,9 @@ function FactoryToolsRail({
     >
       {links.map((link) => (
         <FactoryToolsRailLink
-          currentPathname={currentPathname}
           href={link.href}
           icon={link.icon}
+          isActive={link.isActive}
           key={link.href}
           label={link.label}
           onNavigate={onNavigate}
@@ -291,20 +288,18 @@ function FactoryToolsRail({
 }
 
 function FactoryToolsRailLink({
-  currentPathname,
   href,
   icon,
+  isActive,
   label,
   onNavigate,
 }: {
-  currentPathname: string;
   href: string;
   icon: ReactNode;
+  isActive: boolean;
   label: string;
   onNavigate?: () => void;
 }) {
-  const isActive = currentPathname === href;
-
   return (
     <Link
       aria-label={label}

--- a/app/factory/[factoryId]/secrets/page.tsx
+++ b/app/factory/[factoryId]/secrets/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { useParams } from "next/navigation";
+import FactorySettingsShell from "@/components/factory/FactorySettingsShell";
 import { FactorySecretsPanel } from "../factory-secrets-panel";
 
 export default function FactorySecretsPage() {
   const { factoryId } = useParams<{ factoryId: string }>();
 
   return (
-    <main className="min-h-dvh px-4 py-8">
-      <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
+    <FactorySettingsShell factoryId={factoryId}>
+      <div className="flex w-full max-w-2xl flex-col gap-6">
         <div className="flex flex-col py-2">
           <h1>Factory secrets</h1>
           <p className="text-gray-500 text-sm">
@@ -17,6 +18,6 @@ export default function FactorySecretsPage() {
         </div>
         <FactorySecretsPanel factoryId={factoryId} />
       </div>
-    </main>
+    </FactorySettingsShell>
   );
 }

--- a/app/factory/[factoryId]/settings/page.tsx
+++ b/app/factory/[factoryId]/settings/page.tsx
@@ -4,6 +4,7 @@ import { TrashIcon, WarningIcon } from "@phosphor-icons/react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import FactoryMonogram from "@/components/factory/FactoryMonogram";
+import FactorySettingsShell from "@/components/factory/FactorySettingsShell";
 import Button from "@/components/public/Button";
 import { cn } from "@/helpers/classname-helper";
 import {
@@ -140,8 +141,8 @@ function FactorySettingsPageContent({
   }
 
   return (
-    <main className="min-h-dvh px-4 py-8">
-      <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
+    <FactorySettingsShell factoryId={factoryId}>
+      <div className="flex w-full max-w-2xl flex-col gap-6">
         <div className="flex flex-col py-2">
           <h1>Factory settings</h1>
           <p className="text-grayscale-10 text-sm">
@@ -250,6 +251,6 @@ function FactorySettingsPageContent({
           </div>
         </section>
       </div>
-    </main>
+    </FactorySettingsShell>
   );
 }

--- a/components/factory/FactoryCapabilitySectionPage.tsx
+++ b/components/factory/FactoryCapabilitySectionPage.tsx
@@ -4,6 +4,7 @@ import { Plug, PuzzlePiece } from "@phosphor-icons/react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import CapabilitiesPanel from "@/components/factory/CapabilitiesPanel";
+import FactorySettingsShell from "@/components/factory/FactorySettingsShell";
 import type { AppDb } from "@/lib/db.client";
 import { db } from "@/lib/db.client";
 
@@ -105,8 +106,8 @@ function FactoryCapabilitySectionPageContent({
   }
 
   return (
-    <div className="px-4 py-5 sm:p-6">
-      <div className="mx-auto flex max-w-4xl flex-col gap-6">
+    <FactorySettingsShell factoryId={factoryId}>
+      <div className="flex max-w-4xl flex-col gap-6">
         <header className="flex flex-col gap-3 border-b border-grayscale-3 pb-6">
           <div className="flex min-w-0 flex-col gap-3">
             <div className="flex size-10 items-center justify-center rounded-lg border border-grayscale-4 bg-grayscale-2 text-accent-11">
@@ -125,7 +126,7 @@ function FactoryCapabilitySectionPageContent({
 
         <CapabilitiesPanel factoryId={factoryId} section={section} />
       </div>
-    </div>
+    </FactorySettingsShell>
   );
 }
 

--- a/components/factory/FactorySettingsShell.tsx
+++ b/components/factory/FactorySettingsShell.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  FadersIcon,
+  FilesIcon,
+  LockKeyIcon,
+  PlugsConnectedIcon,
+} from "@phosphor-icons/react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import { cn } from "@/helpers/classname-helper";
+
+const settingsSections = [
+  {
+    icon: <FadersIcon aria-hidden="true" size={15} weight="bold" />,
+    label: "Settings",
+    path: "settings",
+  },
+  {
+    icon: <LockKeyIcon aria-hidden="true" size={15} weight="bold" />,
+    label: "Secrets",
+    path: "secrets",
+  },
+  {
+    icon: <FilesIcon aria-hidden="true" size={15} weight="bold" />,
+    label: "Skills",
+    path: "skills",
+  },
+  {
+    icon: <PlugsConnectedIcon aria-hidden="true" size={15} weight="bold" />,
+    label: "MCP",
+    path: "mcp",
+  },
+];
+
+export default function FactorySettingsShell({
+  children,
+  factoryId,
+}: {
+  children: ReactNode;
+  factoryId: string;
+}) {
+  const pathname = usePathname();
+
+  return (
+    <main className="min-h-dvh px-4 py-8">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 md:flex-row md:items-start">
+        <aside className="md:sticky md:top-8 md:w-44 md:shrink-0">
+          <nav
+            aria-label="Factory settings"
+            className="flex gap-1 overflow-x-auto border-grayscale-3 border-b pb-2 md:flex-col md:overflow-visible md:border-b-0 md:pb-0"
+          >
+            {settingsSections.map((section) => {
+              const href = `/factory/${factoryId}/${section.path}`;
+              const isActive = pathname === href;
+
+              return (
+                <Link
+                  className={cn(
+                    "flex h-9 shrink-0 items-center gap-2 rounded-md px-2 text-grayscale-11 text-sm transition-colors hover:bg-grayscale-2 hover:text-grayscale-12",
+                    isActive &&
+                      "bg-grayscale-3 text-grayscale-12 hover:bg-grayscale-3",
+                  )}
+                  href={href}
+                  key={section.path}
+                >
+                  {section.icon}
+                  <span className="font-medium">{section.label}</span>
+                </Link>
+              );
+            })}
+          </nav>
+        </aside>
+        <div className="min-w-0 flex-1">{children}</div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- reduce the factory rail to Workers and Settings
- use ChatsTeardrop for Workers and Faders for Settings
- add a shared settings sidebar for Settings, Secrets, Skills, and MCP

## Test
- npm run check
- npx tsc --noEmit