### PR TITLE
Split computer links from settings sidebar

### DIFF
--- a/app/factory/[factoryId]/layout.tsx
+++ b/app/factory/[factoryId]/layout.tsx
@@ -4,6 +4,7 @@ import NumberFlow from "@number-flow/react";
 import {
   ChatsTeardropIcon,
   CircleNotchIcon,
+  DesktopTowerIcon,
   FadersIcon,
   GearSixIcon,
   ListIcon,
@@ -17,6 +18,7 @@ import Link from "next/link";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
+import FactoryComputerSidebar from "@/components/factory/FactoryComputerSidebar";
 import FactoryMonogram from "@/components/factory/FactoryMonogram";
 import FactorySettingsSidebar from "@/components/factory/FactorySettingsSidebar";
 import Button from "@/components/public/Button";
@@ -124,6 +126,7 @@ function FactoryLayoutContent({
     (b.createdAt ?? "").localeCompare(a.createdAt ?? ""),
   );
   const isSettingsSection = isFactorySettingsPath(pathname, factoryId);
+  const isComputerSection = isFactoryComputerPath(pathname, factoryId);
 
   if (!isLoading && !factory) {
     return (
@@ -152,6 +155,8 @@ function FactoryLayoutContent({
       <aside className="hidden border-grayscale-3 border-r md:sticky md:top-0 md:block md:h-dvh">
         {isSettingsSection ? (
           <FactorySettingsSidebar factoryId={factoryId} />
+        ) : isComputerSection ? (
+          <FactoryComputerSidebar factoryId={factoryId} />
         ) : (
           <WorkerSidebar
             currentPathname={pathname}
@@ -203,6 +208,12 @@ function FactoryLayoutContent({
             />
             {isSettingsSection ? (
               <FactorySettingsSidebar
+                className="w-full"
+                factoryId={factoryId}
+                onNavigate={() => setIsSidebarOpen(false)}
+              />
+            ) : isComputerSection ? (
+              <FactoryComputerSidebar
                 className="w-full"
                 factoryId={factoryId}
                 onNavigate={() => setIsSidebarOpen(false)}
@@ -266,14 +277,19 @@ function FactoryToolsRail({
       label: "Workers",
     },
     {
-      href: `/factory/${factoryId}/settings`,
-      icon: <FadersIcon aria-hidden="true" size={17} weight="bold" />,
+      href: `/factory/${factoryId}/mcp`,
+      icon: <DesktopTowerIcon aria-hidden="true" size={17} weight="bold" />,
       isActive: [
-        `/factory/${factoryId}/settings`,
         `/factory/${factoryId}/secrets`,
         `/factory/${factoryId}/skills`,
         `/factory/${factoryId}/mcp`,
       ].includes(currentPathname),
+      label: "Computer",
+    },
+    {
+      href: `/factory/${factoryId}/settings`,
+      icon: <FadersIcon aria-hidden="true" size={17} weight="bold" />,
+      isActive: [`/factory/${factoryId}/settings`].includes(currentPathname),
       label: "Settings",
     },
   ];
@@ -302,8 +318,11 @@ function FactoryToolsRail({
 }
 
 function isFactorySettingsPath(pathname: string, factoryId: string) {
+  return pathname === `/factory/${factoryId}/settings`;
+}
+
+function isFactoryComputerPath(pathname: string, factoryId: string) {
   return [
-    `/factory/${factoryId}/settings`,
     `/factory/${factoryId}/secrets`,
     `/factory/${factoryId}/skills`,
     `/factory/${factoryId}/mcp`,

--- a/app/factory/[factoryId]/settings/page.tsx
+++ b/app/factory/[factoryId]/settings/page.tsx
@@ -149,10 +149,13 @@ function FactorySettingsPageContent({
           </p>
         </div>
 
-        <section className="overflow-hidden rounded-lg border border-grayscale-3 bg-grayscale-1">
+        <section
+          className="overflow-hidden rounded-lg border border-grayscale-3 bg-grayscale-1"
+          id="general"
+        >
           <div className="border-grayscale-3 border-b px-3 py-2">
             <h2 className="font-mono font-bold text-[11px] text-grayscale-10 uppercase tracking-wide">
-              Factory color
+              General
             </h2>
           </div>
           <div className="flex flex-col gap-4 px-3 py-3">
@@ -208,7 +211,10 @@ function FactorySettingsPageContent({
           </div>
         </section>
 
-        <section className="overflow-hidden rounded-lg border border-red-6 bg-red-2">
+        <section
+          className="overflow-hidden rounded-lg border border-red-6 bg-red-2"
+          id="danger-zone"
+        >
           <div className="border-red-6 border-b px-3 py-2">
             <h2 className="font-mono font-bold text-[11px] text-red-11 uppercase tracking-wide">
               Danger zone

--- a/components/factory/FactoryComputerSidebar.tsx
+++ b/components/factory/FactoryComputerSidebar.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+  FilesIcon,
+  LockKeyIcon,
+  PlugsConnectedIcon,
+} from "@phosphor-icons/react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/helpers/classname-helper";
+
+const computerSections = [
+  {
+    icon: <PlugsConnectedIcon aria-hidden="true" size={15} weight="bold" />,
+    label: "MCP",
+    path: "mcp",
+  },
+  {
+    icon: <FilesIcon aria-hidden="true" size={15} weight="bold" />,
+    label: "Skills",
+    path: "skills",
+  },
+  {
+    icon: <LockKeyIcon aria-hidden="true" size={15} weight="bold" />,
+    label: "Secrets",
+    path: "secrets",
+  },
+];
+
+export default function FactoryComputerSidebar({
+  className,
+  factoryId,
+  onNavigate,
+}: {
+  className?: string;
+  factoryId: string;
+  onNavigate?: () => void;
+}) {
+  const pathname = usePathname();
+
+  return (
+    <div className={cn("flex h-full min-h-0 w-64 flex-col p-2", className)}>
+      <nav aria-label="Factory computer" className="flex flex-col gap-1">
+        <h2 className="mt-2 px-2 pb-1 font-mono font-semibold text-grayscale-10 text-xs uppercase">
+          Computer
+        </h2>
+        {computerSections.map((section) => {
+          const href = `/factory/${factoryId}/${section.path}`;
+          const isActive = pathname === href;
+
+          return (
+            <Link
+              className={cn(
+                "flex h-9 items-center gap-2 rounded-md px-2 text-grayscale-11 text-sm transition-colors hover:bg-grayscale-2 hover:text-grayscale-12",
+                isActive &&
+                  "bg-grayscale-3 text-grayscale-12 hover:bg-grayscale-3",
+              )}
+              href={href}
+              key={section.path}
+              onClick={onNavigate}
+            >
+              {section.icon}
+              <span className="font-medium">{section.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/components/factory/FactorySettingsSidebar.tsx
+++ b/components/factory/FactorySettingsSidebar.tsx
@@ -1,35 +1,20 @@
 "use client";
 
-import {
-  FadersIcon,
-  FilesIcon,
-  LockKeyIcon,
-  PlugsConnectedIcon,
-} from "@phosphor-icons/react";
+import { FadersIcon, WarningIcon } from "@phosphor-icons/react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 import { cn } from "@/helpers/classname-helper";
 
 const settingsSections = [
   {
     icon: <FadersIcon aria-hidden="true" size={15} weight="bold" />,
-    label: "Settings",
-    path: "settings",
+    id: "general",
+    label: "General",
   },
   {
-    icon: <LockKeyIcon aria-hidden="true" size={15} weight="bold" />,
-    label: "Secrets",
-    path: "secrets",
-  },
-  {
-    icon: <FilesIcon aria-hidden="true" size={15} weight="bold" />,
-    label: "Skills",
-    path: "skills",
-  },
-  {
-    icon: <PlugsConnectedIcon aria-hidden="true" size={15} weight="bold" />,
-    label: "MCP",
-    path: "mcp",
+    icon: <WarningIcon aria-hidden="true" size={15} weight="bold" />,
+    id: "danger-zone",
+    label: "Danger zone",
   },
 ];
 
@@ -42,7 +27,20 @@ export default function FactorySettingsSidebar({
   factoryId: string;
   onNavigate?: () => void;
 }) {
-  const pathname = usePathname();
+  const [activeSectionId, setActiveSectionId] = useState("general");
+
+  useEffect(() => {
+    function syncHash() {
+      setActiveSectionId(
+        window.location.hash === "#danger-zone" ? "danger-zone" : "general",
+      );
+    }
+
+    syncHash();
+    window.addEventListener("hashchange", syncHash);
+
+    return () => window.removeEventListener("hashchange", syncHash);
+  }, []);
 
   return (
     <div className={cn("flex h-full min-h-0 w-64 flex-col p-2", className)}>
@@ -51,8 +49,8 @@ export default function FactorySettingsSidebar({
           Settings
         </h2>
         {settingsSections.map((section) => {
-          const href = `/factory/${factoryId}/${section.path}`;
-          const isActive = pathname === href;
+          const href = `/factory/${factoryId}/settings#${section.id}`;
+          const isActive = activeSectionId === section.id;
 
           return (
             <Link
@@ -62,7 +60,7 @@ export default function FactorySettingsSidebar({
                   "bg-grayscale-3 text-grayscale-12 hover:bg-grayscale-3",
               )}
               href={href}
-              key={section.path}
+              key={section.id}
               onClick={onNavigate}
             >
               {section.icon}


### PR DESCRIPTION
## Summary
- add a Computer rail item with DesktopTowerIcon
- move MCP, Skills, and Secrets into a Computer sidebar
- reduce Settings sidebar to General and Danger zone anchors

## Test
- npm run check
- npx tsc --noEmit