### PR TITLE
Apply Git identity before worker runs

### DIFF
--- a/jobs/run-worker.ts
+++ b/jobs/run-worker.ts
@@ -1,6 +1,7 @@
 import { id } from "@instantdb/admin";
 import { logger, metadata, task, tasks } from "@trigger.dev/sdk";
 import { getAppPublicUrl, getFactoryMcpGatewayUrl } from "@/lib/app-url";
+import { applyGitIdentity, type GithubSetup } from "@/lib/codex/github-setup";
 import {
   cleanCommandOutput,
   ensureLatestCodexOnSandbox,
@@ -44,6 +45,7 @@ type WorkerRecord = {
   codexSessionId?: string;
   factory?: {
     defaultSandboxCheckpointId?: string;
+    githubSettings?: Pick<GithubSetup, "gitEmail" | "gitName">;
     id: string;
     secrets?: SecretRecord[];
   };
@@ -214,6 +216,17 @@ export const runWorkerTask = task({
         sandboxRecreated,
         sandboxId,
         shouldInterrupt,
+        workerId: worker.id,
+      });
+
+      await applyGitIdentity(sandbox, {
+        gitEmail: worker.factory.githubSettings?.gitEmail,
+        gitName: worker.factory.githubSettings?.gitName,
+      });
+      logTaskStep("info", "Git identity applied to worker sandbox", {
+        hasGitEmail: Boolean(worker.factory.githubSettings?.gitEmail),
+        hasGitName: Boolean(worker.factory.githubSettings?.gitName),
+        sandboxId,
         workerId: worker.id,
       });
 
@@ -463,6 +476,7 @@ async function getWorker(workerId: string) {
     workers: {
       $: { where: { id: workerId } },
       factory: {
+        githubSettings: {},
         secrets: {},
       },
     },

--- a/lib/codex/github-setup.ts
+++ b/lib/codex/github-setup.ts
@@ -44,18 +44,31 @@ export async function applyGithubSetup(
   }
 }
 
-function createGithubSetupCommands(setup: GithubSetup) {
-  const commands: string[] = [];
+export async function applyGitIdentity(
+  sandbox: AppSandbox,
+  setup: Pick<GithubSetup, "gitEmail" | "gitName">,
+) {
+  const commands = createGitIdentityCommands(setup);
 
-  if (setup.gitName) {
-    commands.push(`git config --global user.name ${shellQuote(setup.gitName)}`);
+  if (commands.length === 0) {
+    return;
   }
 
-  if (setup.gitEmail) {
-    commands.push(
-      `git config --global user.email ${shellQuote(setup.gitEmail)}`,
+  const result = await runSandboxCommand(
+    sandbox,
+    ["set -e", ...commands].join("\n"),
+    30_000,
+  );
+
+  if (!result.success) {
+    throw new Error(
+      `Git identity setup failed: ${cleanCommandOutput(result.output) || "No output"}`,
     );
   }
+}
+
+function createGithubSetupCommands(setup: GithubSetup) {
+  const commands = createGitIdentityCommands(setup);
 
   if (setup.token) {
     const credential = `https://x-access-token:${setup.token}@github.com`;
@@ -69,6 +82,24 @@ function createGithubSetupCommands(setup: GithubSetup) {
 
   for (const repository of setup.repositories) {
     commands.push(createCloneCommand(repository));
+  }
+
+  return commands;
+}
+
+function createGitIdentityCommands(
+  setup: Pick<GithubSetup, "gitEmail" | "gitName">,
+) {
+  const commands: string[] = [];
+
+  if (setup.gitName) {
+    commands.push(`git config --global user.name ${shellQuote(setup.gitName)}`);
+  }
+
+  if (setup.gitEmail) {
+    commands.push(
+      `git config --global user.email ${shellQuote(setup.gitEmail)}`,
+    );
   }
 
   return commands;


### PR DESCRIPTION
## Summary
- reapply configured factory Git name/email before each worker run
- load factory GitHub settings with worker run inputs
- reuse Git identity setup separately from token and clone setup

## Verification
- pnpm typecheck
- pnpm exec biome check jobs/run-worker.ts lib/codex/github-setup.ts

Note: full pnpm check still reports an unrelated existing formatting issue in app/page.tsx.