### PR TITLE
Fix worker model menu

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,15 +71,17 @@ export default function Home() {
         <div className="flex flex-col gap-px p-2">
           <div className="flex flex-row items-center gap-2">
             <Logo className="size-9 rounded-md" />
-            <p className="text-md font-medium leading-6 text-grayscale-12">FactoryPlane</p>
+            <p className="text-md font-medium leading-6 text-grayscale-12">
+              FactoryPlane
+            </p>
           </div>
           <p className="max-w-lg text-balance text-lg font-medium leading-6 text-grayscale-12 mt-8">
             Open source, collaborative software factory running in the cloud
             using your existing coding agents.
           </p>
           <p className="max-w-lg text-balance text-sm leading-6 text-grayscale-11 mt-1">
-            Spin up workers in the cloud, invite supervisors, and steer the
-            work together — all from one place.
+            Spin up workers in the cloud, invite supervisors, and steer the work
+            together — all from one place.
           </p>
           <div className="mt-4 flex flex-row flex-wrap items-center gap-2">
             <Button className="text-xs" href="/login" variant="primary">

--- a/components/factory/WorkerRunOptions.tsx
+++ b/components/factory/WorkerRunOptions.tsx
@@ -46,59 +46,56 @@ export function WorkerRunOptions({
   }
 
   return (
-    <Menu.Composed
-      modal={false}
-      popupProps={{ className: "w-64" }}
-      positionerProps={{ sideOffset: 8 }}
-      showArrow={false}
-      trigger={
-        <>
-          <Lightning size={16} weight="bold" aria-hidden="true" />
-          <span className="font-semibold text-grayscale-12">
-            {getCompactModelLabel(model)}
-          </span>
-          <span>{reasoningLabel}</span>
-          <span className="sr-only">worker settings</span>
-          <CaretDown size={14} weight="bold" aria-hidden="true" />
-        </>
-      }
-      triggerProps={{
-        "aria-label": `Worker settings: ${modelLabel}, ${reasoningLabel}, ${speedLabel}`,
-        className:
-          "h-9 text-grayscale-10 disabled:cursor-not-allowed disabled:opacity-60",
-        disabled,
-        type: "button",
-      }}
-    >
-      <WorkerRunOptionsSubmenu
-        label="Model"
-        selectedLabel={modelLabel}
-        value={model}
-        onValueChange={(value) => onModelChange(value as WorkerModel)}
-        options={workerModelOptions}
-      />
-      <WorkerRunOptionsSubmenu
-        label="Reasoning"
-        selectedLabel={reasoningLabel}
-        value={reasoningLevel}
-        onValueChange={(value) =>
-          setReasoningLevel(value as WorkerReasoningLevel)
-        }
-        options={workerReasoningLevelOptions}
-      />
-      <WorkerRunOptionsSubmenu
-        getDisabled={(value) =>
-          value === "fast" && !isFastAvailable
-            ? "Fast mode is available for GPT-5.5 and GPT-5.4."
-            : undefined
-        }
-        label="Speed"
-        selectedLabel={speedLabel}
-        value={speed}
-        onValueChange={(value) => setSpeed(value as WorkerSpeed)}
-        options={workerSpeedOptions}
-      />
-    </Menu.Composed>
+    <Menu.Root modal={false}>
+      <Menu.Trigger
+        aria-label={`Worker settings: ${modelLabel}, ${reasoningLabel}, ${speedLabel}`}
+        className="h-9 text-grayscale-10 disabled:cursor-not-allowed disabled:opacity-60"
+        disabled={disabled}
+        type="button"
+      >
+        <Lightning size={16} weight="bold" aria-hidden="true" />
+        <span className="font-semibold text-grayscale-12">
+          {getCompactModelLabel(model)}
+        </span>
+        <span>{reasoningLabel}</span>
+        <span className="sr-only">worker settings</span>
+        <CaretDown size={14} weight="bold" aria-hidden="true" />
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner sideOffset={8}>
+          <Menu.Popup className="w-64">
+            <WorkerRunOptionsSubmenu
+              label="Model"
+              selectedLabel={modelLabel}
+              value={model}
+              onValueChange={(value) => onModelChange(value as WorkerModel)}
+              options={workerModelOptions}
+            />
+            <WorkerRunOptionsSubmenu
+              label="Reasoning"
+              selectedLabel={reasoningLabel}
+              value={reasoningLevel}
+              onValueChange={(value) =>
+                setReasoningLevel(value as WorkerReasoningLevel)
+              }
+              options={workerReasoningLevelOptions}
+            />
+            <WorkerRunOptionsSubmenu
+              getDisabled={(value) =>
+                value === "fast" && !isFastAvailable
+                  ? "Fast mode is available for GPT-5.5 and GPT-5.4."
+                  : undefined
+              }
+              label="Speed"
+              selectedLabel={speedLabel}
+              value={speed}
+              onValueChange={(value) => setSpeed(value as WorkerSpeed)}
+              options={workerSpeedOptions}
+            />
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
   );
 }
 
@@ -121,32 +118,34 @@ function WorkerRunOptionsSubmenu<TValue extends string>({
     <Menu.SubmenuRoot>
       <Menu.SubmenuTrigger>
         <span>{label}</span>
-        <span className="ml-auto mr-4 text-grayscale-9 text-xs">
+        <span className="min-w-0 max-w-32 truncate text-right text-grayscale-9 text-xs">
           {selectedLabel}
         </span>
       </Menu.SubmenuTrigger>
       <Menu.Portal>
-        <Menu.Positioner sideOffset={8}>
+        <Menu.Positioner
+          align="start"
+          collisionAvoidance={{ fallbackAxisSide: "none" }}
+          side="inline-end"
+        >
           <Menu.Popup className="w-48">
-            <Menu.Viewport>
-              <Menu.RadioGroup value={value} onValueChange={onValueChange}>
-                {options.map((option) => {
-                  const disabledReason = getDisabled?.(option.value);
+            <Menu.RadioGroup value={value} onValueChange={onValueChange}>
+              {options.map((option) => {
+                const disabledReason = getDisabled?.(option.value);
 
-                  return (
-                    <Menu.RadioItem
-                      disabled={Boolean(disabledReason)}
-                      key={option.value}
-                      title={disabledReason}
-                      value={option.value}
-                    >
-                      <Menu.RadioItemIndicator />
-                      <span>{option.label}</span>
-                    </Menu.RadioItem>
-                  );
-                })}
-              </Menu.RadioGroup>
-            </Menu.Viewport>
+                return (
+                  <Menu.RadioItem
+                    disabled={Boolean(disabledReason)}
+                    key={option.value}
+                    title={disabledReason}
+                    value={option.value}
+                  >
+                    <Menu.RadioItemIndicator />
+                    <span>{option.label}</span>
+                  </Menu.RadioItem>
+                );
+              })}
+            </Menu.RadioGroup>
           </Menu.Popup>
         </Menu.Positioner>
       </Menu.Portal>

--- a/components/public/Menu.tsx
+++ b/components/public/Menu.tsx
@@ -1,4 +1,5 @@
 import { Menu as BaseMenu } from "@base-ui/react/menu";
+import { CaretRight } from "@phosphor-icons/react";
 import { cn } from "@/helpers/classname-helper";
 
 type MenuComposedProps = Omit<
@@ -44,11 +45,9 @@ const Backdrop = ({
 
 const Positioner = ({
   className,
-  sideOffset = 6,
   ...props
 }: React.ComponentProps<typeof BaseMenu.Positioner>) => (
   <BaseMenu.Positioner
-    sideOffset={sideOffset}
     className={cn("z-50 outline-none", className)}
     {...props}
   />
@@ -211,13 +210,26 @@ const SubmenuRoot = (
 ) => <BaseMenu.SubmenuRoot {...props} />;
 
 const SubmenuTrigger = ({
+  children,
   className,
   ...props
 }: React.ComponentProps<typeof BaseMenu.SubmenuTrigger>) => (
   <BaseMenu.SubmenuTrigger
-    className={cn(itemClasses, "after:ml-auto after:content-['>']", className)}
+    className={cn(
+      itemClasses,
+      "grid grid-cols-[minmax(0,1fr)_auto_auto]",
+      className,
+    )}
     {...props}
-  />
+  >
+    {children}
+    <CaretRight
+      aria-hidden="true"
+      className="text-grayscale-8"
+      size={12}
+      weight="bold"
+    />
+  </BaseMenu.SubmenuTrigger>
 );
 
 const Composed = ({


### PR DESCRIPTION
## Summary
- restructure worker run options to use Base UI menu primitives directly for nested submenus
- remove the shared menu positioner default offset so nested menus use Base UI positioning defaults
- fix Biome formatting on the homepage copy block

## Checks
- pnpm check
- pnpm typecheck
- pnpm test:unit