### PR TITLE
Persist worker defaults on agents

### DIFF
--- a/app/api/factories/route.ts
+++ b/app/api/factories/route.ts
@@ -68,11 +68,7 @@ export async function POST(request: Request) {
   try {
     const sandbox = await createFactorySandbox(factoryId);
     await applyGithubSetup(sandbox, githubSettings);
-    const serializedCodexAuthJson = isJsonObject(codexAuthJson)
-      ? JSON.stringify(codexAuthJson, null, 2)
-      : undefined;
     const checkpoint = await createDefaultFactoryCheckpoint({
-      codexAuthJson: serializedCodexAuthJson,
       factoryId,
       sandbox,
     });
@@ -118,6 +114,15 @@ export async function POST(request: Request) {
           ...factoryTransactions,
           db.tx.agents[agentId].update({
             authEncrypted: encryptSecretValue(codexAuthJson),
+            codexModel: "gpt-5.5",
+            codexReasoningLevel: "medium",
+            codexSpeed: "standard",
+            ...(githubSettings.gitEmail
+              ? { gitEmail: githubSettings.gitEmail }
+              : {}),
+            ...(githubSettings.gitName
+              ? { gitName: githubSettings.gitName }
+              : {}),
             type: "codex",
           }),
           db.tx.agents[agentId].link({

--- a/app/factories/new/page.tsx
+++ b/app/factories/new/page.tsx
@@ -1009,8 +1009,8 @@ function AgentStep({
                   className="min-h-48 w-full resize-y rounded-lg border border-grayscale-3 bg-grayscale-1 p-3 font-mono text-grayscale-12 text-xs outline-none transition-colors placeholder:text-grayscale-9 focus:border-accent-9 dark:bg-grayscale-1"
                 />
                 <span className="text-grayscale-10 text-xs">
-                  Saved encrypted on the agent and copied as a file into the
-                  default snapshot.
+                  Saved encrypted on the agent and installed into worker
+                  sandboxes created with that agent.
                 </span>
               </label>
             </div>

--- a/app/factory/[factoryId]/settings/_components/FactorySettingsSectionPage.tsx
+++ b/app/factory/[factoryId]/settings/_components/FactorySettingsSectionPage.tsx
@@ -13,6 +13,7 @@ import {
   FactorySectionCard,
   FactorySectionPageShell,
 } from "@/components/factory/FactorySectionLayout";
+import { WorkerRunOptions } from "@/components/factory/WorkerRunOptions";
 import Button from "@/components/public/Button";
 import Input from "@/components/public/Input";
 import { cn } from "@/helpers/classname-helper";
@@ -28,6 +29,14 @@ import {
   isFactoryTrialing,
   PRO_BILLING_PLAN,
 } from "@/lib/billing";
+import {
+  normalizeWorkerModel,
+  normalizeWorkerReasoningLevel,
+  normalizeWorkerSpeed,
+  type WorkerModel,
+  type WorkerReasoningLevel,
+  type WorkerSpeed,
+} from "@/lib/codex/worker-options";
 import type { AppDb } from "@/lib/db.client";
 import { db } from "@/lib/db.client";
 import { clearLastFactoryId } from "@/lib/factory/last-factory";
@@ -50,6 +59,11 @@ type SupervisorRecord = {
 };
 
 type AgentRecord = {
+  codexModel?: string;
+  codexReasoningLevel?: string;
+  codexSpeed?: string;
+  gitEmail?: string;
+  gitName?: string;
   id: string;
   type?: string;
 };
@@ -422,7 +436,11 @@ function FactorySettingsPageContent({
       ) : null}
 
       {section === "agents" ? (
-        <FactoryAgentsPanel agents={agents} isLoading={isLoading} />
+        <FactoryAgentsPanel
+          agents={agents}
+          instantDb={instantDb}
+          isLoading={isLoading}
+        />
       ) : null}
 
       {section === "billing" ? (
@@ -533,9 +551,11 @@ function FactorySettingsPageContent({
 
 function FactoryAgentsPanel({
   agents,
+  instantDb,
   isLoading,
 }: {
   agents: AgentRecord[];
+  instantDb: AppDb;
   isLoading: boolean;
 }) {
   return (
@@ -546,25 +566,31 @@ function FactoryAgentsPanel({
         ) : agents.length > 0 ? (
           agents.map((agent) => (
             <div
-              className="flex min-h-10 items-center justify-between gap-3 rounded-lg border border-grayscale-3 bg-grayscale-1 px-3"
+              className="flex flex-col gap-3 rounded-lg border border-grayscale-3 bg-grayscale-1 p-3"
               key={agent.id}
             >
-              <div className="flex min-w-0 items-center gap-3">
-                <div className="flex size-8 shrink-0 items-center justify-center rounded-md border border-grayscale-3 bg-grayscale-2 text-grayscale-11">
-                  <CpuIcon aria-hidden="true" size={16} weight="bold" />
+              <div className="flex min-h-10 items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-3">
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-md border border-grayscale-3 bg-grayscale-2 text-grayscale-11">
+                    <CpuIcon aria-hidden="true" size={16} weight="bold" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-grayscale-12 text-sm">
+                      {formatAgentType(agent.type)}
+                    </p>
+                    <p className="truncate font-mono text-grayscale-10 text-xs">
+                      {agent.id}
+                    </p>
+                  </div>
                 </div>
-                <div className="min-w-0">
-                  <p className="truncate font-medium text-grayscale-12 text-sm">
-                    {formatAgentType(agent.type)}
-                  </p>
-                  <p className="truncate font-mono text-grayscale-10 text-xs">
-                    {agent.id}
-                  </p>
+                <div className="flex shrink-0 items-center gap-2">
+                  <AgentDefaultOptions agent={agent} instantDb={instantDb} />
+                  <span className="rounded-md border border-grayscale-3 bg-grayscale-2 px-2 py-0.5 font-medium text-grayscale-10 text-xs">
+                    Connected
+                  </span>
                 </div>
               </div>
-              <span className="shrink-0 rounded-md border border-grayscale-3 bg-grayscale-2 px-2 py-0.5 font-medium text-grayscale-10 text-xs">
-                Connected
-              </span>
+              <AgentIdentityOptions agent={agent} instantDb={instantDb} />
             </div>
           ))
         ) : (
@@ -579,6 +605,139 @@ function FactoryAgentsPanel({
         )}
       </div>
     </FactorySectionCard>
+  );
+}
+
+function AgentIdentityOptions({
+  agent,
+  instantDb,
+}: {
+  agent: AgentRecord;
+  instantDb: AppDb;
+}) {
+  const gitNameId = useId();
+  const gitEmailId = useId();
+  const [gitName, setGitName] = useState(agent.gitName ?? "");
+  const [gitEmail, setGitEmail] = useState(agent.gitEmail ?? "");
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setGitName(agent.gitName ?? "");
+    setGitEmail(agent.gitEmail ?? "");
+  }, [agent.gitEmail, agent.gitName]);
+
+  const trimmedGitName = gitName.trim();
+  const trimmedGitEmail = gitEmail.trim();
+  const hasChanges =
+    trimmedGitName !== (agent.gitName ?? "") ||
+    trimmedGitEmail !== (agent.gitEmail ?? "");
+
+  async function saveIdentity() {
+    setIsSaving(true);
+
+    try {
+      await instantDb.transact(
+        instantDb.tx.agents[agent.id].update({
+          gitEmail: trimmedGitEmail,
+          gitName: trimmedGitName,
+        }),
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-2 border-grayscale-3 border-t pt-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-end">
+      <label className="flex min-w-0 flex-col gap-1.5" htmlFor={gitNameId}>
+        <span className="font-medium text-grayscale-12 text-xs">Git name</span>
+        <Input
+          className="h-9 bg-grayscale-1 dark:bg-grayscale-1"
+          disabled={isSaving}
+          id={gitNameId}
+          onChange={(event) => setGitName(event.target.value)}
+          placeholder="Factory default"
+          value={gitName}
+        />
+      </label>
+      <label className="flex min-w-0 flex-col gap-1.5" htmlFor={gitEmailId}>
+        <span className="font-medium text-grayscale-12 text-xs">Git email</span>
+        <Input
+          autoComplete="email"
+          className="h-9 bg-grayscale-1 dark:bg-grayscale-1"
+          disabled={isSaving}
+          id={gitEmailId}
+          onChange={(event) => setGitEmail(event.target.value)}
+          placeholder="Factory default"
+          value={gitEmail}
+        />
+      </label>
+      <Button
+        className="h-9 justify-center"
+        disabled={isSaving || !hasChanges}
+        onClick={saveIdentity}
+        type="button"
+        variant="secondary"
+      >
+        {isSaving ? "Saving..." : "Save identity"}
+      </Button>
+    </div>
+  );
+}
+
+function AgentDefaultOptions({
+  agent,
+  instantDb,
+}: {
+  agent: AgentRecord;
+  instantDb: AppDb;
+}) {
+  const model = normalizeWorkerModel(agent.codexModel);
+  const reasoningLevel = normalizeWorkerReasoningLevel(
+    agent.codexReasoningLevel,
+  );
+  const speed = normalizeWorkerSpeed({
+    model,
+    speed: agent.codexSpeed,
+  });
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function updateDefaults(updates: {
+    codexModel?: WorkerModel;
+    codexReasoningLevel?: WorkerReasoningLevel;
+    codexSpeed?: WorkerSpeed;
+  }) {
+    setIsSaving(true);
+
+    try {
+      await instantDb.transact(instantDb.tx.agents[agent.id].update(updates));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <WorkerRunOptions
+      disabled={isSaving}
+      model={model}
+      reasoningLevel={reasoningLevel}
+      setModel={(nextModel) =>
+        updateDefaults({
+          codexModel: nextModel,
+        })
+      }
+      setReasoningLevel={(nextReasoningLevel) =>
+        updateDefaults({
+          codexReasoningLevel: nextReasoningLevel,
+        })
+      }
+      setSpeed={(nextSpeed) =>
+        updateDefaults({
+          codexSpeed: nextSpeed,
+        })
+      }
+      speed={speed}
+    />
   );
 }
 

--- a/app/factory/[factoryId]/worker-message-client.ts
+++ b/app/factory/[factoryId]/worker-message-client.ts
@@ -27,6 +27,7 @@ export async function triggerWorkerRun({
   workerModel,
   workerReasoningLevel,
   worker,
+  workerAgentId,
   workerSpeed,
   workerId: preGeneratedWorkerId,
 }: {
@@ -41,6 +42,7 @@ export async function triggerWorkerRun({
   workerModel?: WorkerModel;
   workerReasoningLevel?: WorkerReasoningLevel;
   worker?: WorkerRecord;
+  workerAgentId?: null | string;
   workerSpeed?: WorkerSpeed;
   workerId?: string;
 }) {
@@ -74,6 +76,11 @@ export async function triggerWorkerRun({
   });
 
   onError(null);
+
+  if (isNewWorker && !workerAgentId) {
+    onError("Select an agent before sending this task to a worker.");
+    return null;
+  }
 
   try {
     const attachmentFileIds = await uploadImageAttachments({
@@ -128,6 +135,14 @@ export async function triggerWorkerRun({
           factory: factoryId,
         }),
       );
+
+      if (workerAgentId) {
+        transactions.push(
+          instantDb.tx.workers[workerId].link({
+            agent: workerAgentId,
+          }),
+        );
+      }
     }
 
     await instantDb.transact(transactions);

--- a/app/factory/[factoryId]/worker-run-form.tsx
+++ b/app/factory/[factoryId]/worker-run-form.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { id } from "@instantdb/react";
+import { Cpu } from "@phosphor-icons/react";
 import { useRouter } from "next/navigation";
-import { type FormEvent, type ReactNode, useRef, useState } from "react";
+import {
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   addImageAttachments,
   cleanupAttachments,
@@ -14,6 +21,7 @@ import {
 } from "@/components/factory/WorkerComposer";
 import { WorkerRunOptions } from "@/components/factory/WorkerRunOptions";
 import Button from "@/components/public/Button";
+import { Menu } from "@/components/public/Menu";
 import {
   defaultWorkerModel,
   defaultWorkerReasoningLevel,
@@ -31,6 +39,7 @@ import { queueWorkerMessage, triggerWorkerRun } from "./worker-message-client";
 
 export type WorkerRecord = {
   activePid?: number;
+  agent?: WorkerAgentRecord;
   codexSessionId?: string;
   codexModel?: string;
   codexReasoningLevel?: string;
@@ -41,6 +50,14 @@ export type WorkerRecord = {
   retiredAt?: string;
   status: string;
   updatedAt?: string;
+};
+
+type WorkerAgentRecord = {
+  codexModel?: string;
+  codexReasoningLevel?: string;
+  codexSpeed?: string;
+  id: string;
+  type?: string;
 };
 
 export function NewWorkerForm({ factoryId }: { factoryId: string }) {
@@ -58,6 +75,8 @@ function NewWorkerFormContent({
   const { user } = instantDb.useAuth();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+  const agents = useFactoryAgents({ factoryId, instantDb });
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [workerModel, setWorkerModel] =
     useState<WorkerModel>(defaultWorkerModel);
   const [workerReasoningLevel, setWorkerReasoningLevel] =
@@ -67,6 +86,15 @@ function NewWorkerFormContent({
   const [prompt, setPrompt] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSending, setIsSending] = useState(false);
+
+  useDefaultSelectedAgent({
+    agents,
+    selectedAgentId,
+    setSelectedAgentId,
+    setWorkerModel,
+    setWorkerReasoningLevel,
+    setWorkerSpeed,
+  });
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -80,6 +108,11 @@ function NewWorkerFormContent({
 
     if (!user?.refresh_token) {
       setError("You must be signed in to run a worker.");
+      return;
+    }
+
+    if (!selectedAgentId) {
+      setError("Select an agent before sending this task to a worker.");
       return;
     }
 
@@ -99,6 +132,7 @@ function NewWorkerFormContent({
       workerModel,
       workerReasoningLevel,
       workerSpeed,
+      workerAgentId: selectedAgentId,
       workerId,
       onError: setError,
     });
@@ -136,15 +170,26 @@ function NewWorkerFormContent({
       prompt={prompt}
       setPrompt={setPrompt}
       startActions={
-        <WorkerRunOptions
-          disabled={isSending}
-          model={workerModel}
-          setModel={setWorkerModel}
-          reasoningLevel={workerReasoningLevel}
-          setReasoningLevel={setWorkerReasoningLevel}
-          setSpeed={setWorkerSpeed}
-          speed={workerSpeed}
-        />
+        <>
+          <WorkerAgentSelector
+            agents={agents}
+            disabled={isSending}
+            selectedAgentId={selectedAgentId}
+            setSelectedAgentId={setSelectedAgentId}
+            setWorkerModel={setWorkerModel}
+            setWorkerReasoningLevel={setWorkerReasoningLevel}
+            setWorkerSpeed={setWorkerSpeed}
+          />
+          <WorkerRunOptions
+            disabled={isSending}
+            model={workerModel}
+            setModel={setWorkerModel}
+            reasoningLevel={workerReasoningLevel}
+            setReasoningLevel={setWorkerReasoningLevel}
+            setSpeed={setWorkerSpeed}
+            speed={workerSpeed}
+          />
+        </>
       }
       submitLabel={isSending ? "Sending..." : "Send"}
       uploadingLabel="Uploading..."
@@ -195,6 +240,8 @@ function WorkerPromptFormContent({
   const { user } = instantDb.useAuth();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+  const agents = useFactoryAgents({ factoryId, instantDb });
+  const selectedAgentId = worker.agent?.id ?? null;
   const [workerModel, setWorkerModel] = useState<WorkerModel>(
     normalizeWorkerModel(worker.codexModel),
   );
@@ -316,19 +363,212 @@ function WorkerPromptFormContent({
       queuedMessages={queuedMessages}
       setPrompt={setPrompt}
       startActions={
-        <WorkerRunOptions
-          disabled={isInputDisabled}
-          model={workerModel}
-          setModel={setWorkerModel}
-          reasoningLevel={workerReasoningLevel}
-          setReasoningLevel={setWorkerReasoningLevel}
-          setSpeed={setWorkerSpeed}
-          speed={workerSpeed}
-        />
+        <>
+          <WorkerAgentSelector
+            agents={agents}
+            disabled
+            selectedAgent={worker.agent}
+            selectedAgentId={selectedAgentId}
+            setWorkerModel={setWorkerModel}
+            setWorkerReasoningLevel={setWorkerReasoningLevel}
+            setWorkerSpeed={setWorkerSpeed}
+          />
+          <WorkerRunOptions
+            disabled={isInputDisabled}
+            model={workerModel}
+            setModel={setWorkerModel}
+            reasoningLevel={workerReasoningLevel}
+            setReasoningLevel={setWorkerReasoningLevel}
+            setSpeed={setWorkerSpeed}
+            speed={workerSpeed}
+          />
+        </>
       }
       submitLabel={isSending ? "Sending..." : isRunning ? "Send now" : "Send"}
       topSection={topSection}
       uploadingLabel="Uploading..."
     />
   );
+}
+
+function useFactoryAgents({
+  factoryId,
+  instantDb,
+}: {
+  factoryId?: string;
+  instantDb: AppDb;
+}) {
+  const { data } = instantDb.useQuery(
+    factoryId
+      ? {
+          factories: {
+            $: { where: { id: factoryId } },
+            agents: {},
+          },
+        }
+      : null,
+  );
+  const agents = (data?.factories?.[0]?.agents ?? []) as WorkerAgentRecord[];
+
+  return [...agents].sort((first, second) =>
+    getAgentLabel(first).localeCompare(getAgentLabel(second)),
+  );
+}
+
+function useDefaultSelectedAgent({
+  agents,
+  selectedAgentId,
+  setSelectedAgentId,
+  setWorkerModel,
+  setWorkerReasoningLevel,
+  setWorkerSpeed,
+}: {
+  agents: WorkerAgentRecord[];
+  selectedAgentId: null | string;
+  setSelectedAgentId: (agentId: null | string) => void;
+  setWorkerModel: (model: WorkerModel) => void;
+  setWorkerReasoningLevel: (reasoningLevel: WorkerReasoningLevel) => void;
+  setWorkerSpeed: (speed: WorkerSpeed) => void;
+}) {
+  useEffect(() => {
+    if (agents.length === 0) {
+      setSelectedAgentId(null);
+      return;
+    }
+
+    if (
+      selectedAgentId &&
+      agents.some((agent) => agent.id === selectedAgentId)
+    ) {
+      return;
+    }
+
+    const agent = agents[0];
+
+    setSelectedAgentId(agent.id);
+    applyAgentDefaults({
+      agent,
+      setWorkerModel,
+      setWorkerReasoningLevel,
+      setWorkerSpeed,
+    });
+  }, [
+    agents,
+    selectedAgentId,
+    setSelectedAgentId,
+    setWorkerModel,
+    setWorkerReasoningLevel,
+    setWorkerSpeed,
+  ]);
+}
+
+function WorkerAgentSelector({
+  agents,
+  disabled,
+  selectedAgent: selectedAgentFallback,
+  selectedAgentId,
+  setSelectedAgentId,
+  setWorkerModel,
+  setWorkerReasoningLevel,
+  setWorkerSpeed,
+}: {
+  agents: WorkerAgentRecord[];
+  disabled?: boolean;
+  selectedAgent?: WorkerAgentRecord;
+  selectedAgentId: null | string;
+  setSelectedAgentId?: (agentId: null | string) => void;
+  setWorkerModel: (model: WorkerModel) => void;
+  setWorkerReasoningLevel: (reasoningLevel: WorkerReasoningLevel) => void;
+  setWorkerSpeed: (speed: WorkerSpeed) => void;
+}) {
+  const selectedAgent =
+    agents.find((agent) => agent.id === selectedAgentId) ??
+    selectedAgentFallback;
+  const selectedLabel = selectedAgent
+    ? getAgentLabel(selectedAgent)
+    : "No agent";
+
+  function onSelectAgent(agent: WorkerAgentRecord) {
+    setSelectedAgentId?.(agent.id);
+    applyAgentDefaults({
+      agent,
+      setWorkerModel,
+      setWorkerReasoningLevel,
+      setWorkerSpeed,
+    });
+  }
+
+  return (
+    <Menu.Root modal={false}>
+      <Menu.Trigger
+        aria-label={`Worker agent: ${selectedLabel}`}
+        className="h-9 text-grayscale-10 disabled:cursor-not-allowed disabled:opacity-60"
+        disabled={disabled || agents.length === 0}
+        type="button"
+      >
+        <Cpu size={16} weight="bold" aria-hidden="true" />
+        <span className="font-semibold text-grayscale-12">{selectedLabel}</span>
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner sideOffset={8}>
+          <Menu.Popup className="w-56">
+            <Menu.RadioGroup
+              value={selectedAgentId ?? ""}
+              onValueChange={(value) => {
+                const agent = agents.find(
+                  (candidate) => candidate.id === value,
+                );
+
+                if (agent) {
+                  onSelectAgent(agent);
+                }
+              }}
+            >
+              {agents.map((agent) => (
+                <Menu.RadioItem key={agent.id} value={agent.id}>
+                  <Menu.RadioItemIndicator />
+                  <span className="min-w-0 truncate">
+                    {getAgentLabel(agent)}
+                  </span>
+                </Menu.RadioItem>
+              ))}
+            </Menu.RadioGroup>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}
+
+function applyAgentDefaults({
+  agent,
+  setWorkerModel,
+  setWorkerReasoningLevel,
+  setWorkerSpeed,
+}: {
+  agent: WorkerAgentRecord;
+  setWorkerModel: (model: WorkerModel) => void;
+  setWorkerReasoningLevel: (reasoningLevel: WorkerReasoningLevel) => void;
+  setWorkerSpeed: (speed: WorkerSpeed) => void;
+}) {
+  const model = normalizeWorkerModel(agent.codexModel);
+
+  setWorkerModel(model);
+  setWorkerReasoningLevel(
+    normalizeWorkerReasoningLevel(agent.codexReasoningLevel),
+  );
+  setWorkerSpeed(
+    normalizeWorkerSpeed({
+      model,
+      speed: agent.codexSpeed,
+    }),
+  );
+}
+
+function getAgentLabel(agent: WorkerAgentRecord) {
+  const typeLabel = agent.type
+    ? `${agent.type.charAt(0).toUpperCase()}${agent.type.slice(1)}`
+    : "Agent";
+
+  return `${typeLabel} ${agent.id.slice(0, 8)}`;
 }

--- a/app/factory/[factoryId]/workers/[workerId]/page.tsx
+++ b/app/factory/[factoryId]/workers/[workerId]/page.tsx
@@ -71,6 +71,7 @@ function WorkerPageContent({ instantDb }: { instantDb: AppDb }) {
       ? {
           workers: {
             $: { where: { id: workerId } },
+            agent: {},
             factory: {},
             ports: {},
           },

--- a/components/factory/WorkerRunOptions.tsx
+++ b/components/factory/WorkerRunOptions.tsx
@@ -53,10 +53,10 @@ export function WorkerRunOptions({
         disabled={disabled}
         type="button"
       >
-        <Lightning size={16} weight="bold" aria-hidden="true" />
-        <span className="font-semibold text-grayscale-12">
-          {getCompactModelLabel(model)}
-        </span>
+        {speed === "fast" ? (
+          <Lightning size={16} weight="fill" aria-hidden="true" />
+        ) : null}
+        <span className="font-semibold text-grayscale-12">{modelLabel}</span>
         <span>{reasoningLabel}</span>
         <span className="sr-only">worker settings</span>
         <CaretDown size={14} weight="bold" aria-hidden="true" />
@@ -158,8 +158,4 @@ function getWorkerOptionLabel<TValue extends string>(
   value: TValue,
 ) {
   return options.find((option) => option.value === value)?.label ?? value;
-}
-
-function getCompactModelLabel(model: WorkerModel) {
-  return model.replace(/^gpt-/, "").replace(/-codex-spark$/, " Spark");
 }

--- a/instant.perms.ts
+++ b/instant.perms.ts
@@ -79,11 +79,27 @@ const rules = {
     },
   },
   agents: {
+    bind: {
+      codexModelIsSupported:
+        "!('codexModel' in request.modifiedFields) || newData.codexModel in ['gpt-5.5', 'gpt-5.4', 'gpt-5.3-codex-spark']",
+      codexReasoningLevelIsSupported:
+        "!('codexReasoningLevel' in request.modifiedFields) || newData.codexReasoningLevel in ['low', 'medium', 'high', 'xhigh']",
+      codexSpeedIsSupported:
+        "!('codexSpeed' in request.modifiedFields) || newData.codexSpeed in ['standard', 'fast']",
+      isFactoryMember:
+        "auth.id in data.ref('factory.owner.id') || auth.id in data.ref('factory.supervisors.user.id')",
+      isOwner: "auth.id in data.ref('factory.owner.id')",
+      onlyUpdatesAgentSettings:
+        "request.modifiedFields.all(field, field in ['codexModel', 'codexReasoningLevel', 'codexSpeed', 'gitEmail', 'gitName']) && codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported",
+    },
     allow: {
-      view: "auth.id in data.ref('factory.owner.id')",
+      view: "isFactoryMember",
       create: "false",
-      update: "false",
+      update: "isOwner && onlyUpdatesAgentSettings",
       delete: "false",
+    },
+    fields: {
+      authEncrypted: "false",
     },
   },
   factoryStripeBillings: {
@@ -119,7 +135,7 @@ const rules = {
       isFactoryMember:
         "auth.id in data.ref('factory.owner.id') || auth.id in data.ref('factory.supervisors.user.id')",
       onlyCreatesClientWorker:
-        "request.modifiedFields.all(field, field in ['codexModel', 'codexReasoningLevel', 'codexSpeed', 'createdAt', 'factory', 'name', 'retiredAt', 'status', 'updatedAt']) && data.status == 'queued' && data.retiredAt == null && codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported",
+        "request.modifiedFields.all(field, field in ['agent', 'codexModel', 'codexReasoningLevel', 'codexSpeed', 'createdAt', 'factory', 'name', 'retiredAt', 'status', 'updatedAt']) && data.status == 'queued' && data.retiredAt == null && codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported",
       onlyQueuesClientWorker:
         "request.modifiedFields.all(field, field in ['codexModel', 'codexReasoningLevel', 'codexSpeed', 'retiredAt', 'status', 'updatedAt']) && newData.retiredAt == null && newData.status in ['queued', 'running'] && codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported",
       onlyRetiresClientWorker:

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -51,6 +51,11 @@ const _schema = i.schema({
     agents: i.entity({
       type: i.string(),
       authEncrypted: i.string(),
+      codexModel: i.string().indexed().optional(),
+      codexReasoningLevel: i.string().indexed().optional(),
+      codexSpeed: i.string().indexed().optional(),
+      gitEmail: i.string().indexed().optional(),
+      gitName: i.string().indexed().optional(),
     }),
     secrets: i.entity({
       createdAt: i.string().indexed(),
@@ -248,6 +253,18 @@ const _schema = i.schema({
       },
       reverse: {
         on: "factories",
+        has: "many",
+        label: "workers",
+      },
+    },
+    workerAgents: {
+      forward: {
+        on: "workers",
+        has: "one",
+        label: "agent",
+      },
+      reverse: {
+        on: "agents",
         has: "many",
         label: "workers",
       },

--- a/jobs/run-worker.ts
+++ b/jobs/run-worker.ts
@@ -6,6 +6,7 @@ import {
   cleanCommandOutput,
   ensureLatestCodexOnSandbox,
   getSandboxStreamChunkText,
+  installCodexAuthOnSandbox,
   killWorkerPid,
   sandboxFactoryDir,
   shellQuote,
@@ -47,6 +48,7 @@ type RunWorkerPayload = {
 type WorkerRecord = {
   activeCommandId?: string;
   activePid?: number;
+  agent?: AgentRecord;
   codexSessionId?: string;
   codexModel?: string;
   codexReasoningLevel?: string;
@@ -60,6 +62,13 @@ type WorkerRecord = {
   id: string;
   sandboxId?: string;
   status?: string;
+};
+
+type AgentRecord = {
+  authEncrypted?: string;
+  gitEmail?: string;
+  gitName?: string;
+  id: string;
 };
 
 type SecretRecord = {
@@ -227,13 +236,24 @@ export const runWorkerTask = task({
         workerId: worker.id,
       });
 
-      await applyGitIdentity(sandbox, {
-        gitEmail: worker.factory.githubSettings?.gitEmail,
-        gitName: worker.factory.githubSettings?.gitName,
-      });
+      if (!resumeCodexSession && worker.agent?.authEncrypted) {
+        await installCodexAuthOnSandbox({
+          codexAuthJson: getAgentCodexAuthJson(worker.agent),
+          sandbox,
+        });
+        logTaskStep("info", "Agent Codex auth installed in worker sandbox", {
+          agentId: worker.agent.id,
+          sandboxId,
+          workerId: worker.id,
+        });
+      }
+
+      const gitIdentity = getWorkerGitIdentity(worker);
+
+      await applyGitIdentity(sandbox, gitIdentity);
       logTaskStep("info", "Git identity applied to worker sandbox", {
-        hasGitEmail: Boolean(worker.factory.githubSettings?.gitEmail),
-        hasGitName: Boolean(worker.factory.githubSettings?.gitName),
+        hasGitEmail: Boolean(gitIdentity.gitEmail),
+        hasGitName: Boolean(gitIdentity.gitName),
         sandboxId,
         workerId: worker.id,
       });
@@ -494,6 +514,7 @@ async function getWorker(workerId: string) {
   const result = await db.query({
     workers: {
       $: { where: { id: workerId } },
+      agent: {},
       factory: {
         githubSettings: {},
         secrets: {},
@@ -502,6 +523,30 @@ async function getWorker(workerId: string) {
   });
 
   return result.workers[0] as WorkerRecord | undefined;
+}
+
+function getAgentCodexAuthJson(agent: AgentRecord) {
+  const authJson = decryptSecretValue<unknown>(agent.authEncrypted);
+
+  if (!isJsonObject(authJson)) {
+    throw new Error("Worker agent Codex auth is missing or invalid");
+  }
+
+  return JSON.stringify(authJson, null, 2);
+}
+
+function getWorkerGitIdentity(worker: WorkerRecord) {
+  return {
+    gitEmail:
+      worker.agent?.gitEmail?.trim() ||
+      worker.factory?.githubSettings?.gitEmail,
+    gitName:
+      worker.agent?.gitName?.trim() || worker.factory?.githubSettings?.gitName,
+  };
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 async function getUserMessageEvent(eventId: string) {

--- a/lib/codex/sandbox-auth.ts
+++ b/lib/codex/sandbox-auth.ts
@@ -47,11 +47,9 @@ Do not print or expose FACTORY_WORKER_API_TOKEN, and do not ask for or handle sa
 `;
 
 export async function createDefaultFactoryCheckpoint({
-  codexAuthJson,
   factoryId,
   sandbox,
 }: {
-  codexAuthJson?: string;
   factoryId: string;
   sandbox: AppSandbox;
 }) {
@@ -61,14 +59,6 @@ export async function createDefaultFactoryCheckpoint({
     `mkdir -p ${shellQuote(factoryDir)}`,
     `printf %s ${shellQuote(marker)} > ${shellQuote(`${factoryDir}/factory.json`)}`,
   ];
-
-  if (codexAuthJson) {
-    commands.push(
-      'mkdir -p "$HOME/.codex"',
-      `printf %s ${shellQuote(codexAuthJson)} > "$HOME/.codex/auth.json"`,
-      'chmod 600 "$HOME/.codex/auth.json"',
-    );
-  }
 
   const result = await runSandboxCommand(
     sandbox,
@@ -85,6 +75,32 @@ export async function createDefaultFactoryCheckpoint({
   }
 
   return createCheckpoint(sandbox, `factory-${factoryId.slice(0, 8)}-default`);
+}
+
+export async function installCodexAuthOnSandbox({
+  codexAuthJson,
+  sandbox,
+}: {
+  codexAuthJson: string;
+  sandbox: AppSandbox;
+}) {
+  const result = await runSandboxCommand(
+    sandbox,
+    [
+      'mkdir -p "$HOME/.codex"',
+      `printf %s ${shellQuote(codexAuthJson)} > "$HOME/.codex/auth.json"`,
+      'chmod 600 "$HOME/.codex/auth.json"',
+    ].join(" && "),
+    30_000,
+  );
+
+  if (!result.success) {
+    throw new Error(
+      `Could not install Codex auth: ${
+        cleanCommandOutput(result.output) || "No output"
+      }`,
+    );
+  }
 }
 
 export async function ensureLatestCodexOnSandbox(sandbox: AppSandbox) {

--- a/tests/unit/auth-permissions.test.ts
+++ b/tests/unit/auth-permissions.test.ts
@@ -28,6 +28,7 @@ test("factory access allows owners and active supervisors only", () => {
 
 test("permissions keep sensitive server-owned records private", () => {
   assert.match(permissionsSource, /valueEncrypted:\s+"false"/);
+  assert.match(permissionsSource, /authEncrypted:\s+"false"/);
   assert.match(permissionsSource, /tokenEncrypted:\s+"false"/);
   assert.match(
     permissionsSource,
@@ -49,6 +50,7 @@ test("permissions keep sensitive server-owned records private", () => {
 
 test("permissions prevent direct creation of server-owned integrations", () => {
   assert.match(permissionsSource, /factories:[\s\S]*?create:\s+"false"/);
+  assert.match(permissionsSource, /agents:[\s\S]*?create:\s+"false"/);
   assert.match(permissionsSource, /secrets:[\s\S]*?create:\s+"false"/);
   assert.match(permissionsSource, /factorySkills:[\s\S]*?create:\s+"false"/);
   assert.match(
@@ -68,10 +70,21 @@ test("supervisor invite acceptance can link the signed-in user", () => {
   );
 });
 
+test("agent permissions allow owners to update supported settings only", () => {
+  assert.match(
+    permissionsSource,
+    /agents:[\s\S]*?onlyUpdatesAgentSettings:[\s\S]*?\['codexModel', 'codexReasoningLevel', 'codexSpeed', 'gitEmail', 'gitName'\][\s\S]*?codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported/,
+  );
+  assert.match(
+    permissionsSource,
+    /agents:[\s\S]*?update:\s+"isOwner && onlyUpdatesAgentSettings"/,
+  );
+});
+
 test("worker permissions keep server-owned runtime fields out of client writes", () => {
   assert.match(
     permissionsSource,
-    /onlyCreatesClientWorker:[\s\S]*?\['codexModel', 'codexReasoningLevel', 'codexSpeed', 'createdAt', 'factory', 'name', 'retiredAt', 'status', 'updatedAt'\][\s\S]*?codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported/,
+    /onlyCreatesClientWorker:[\s\S]*?\['agent', 'codexModel', 'codexReasoningLevel', 'codexSpeed', 'createdAt', 'factory', 'name', 'retiredAt', 'status', 'updatedAt'\][\s\S]*?codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported/,
   );
   assert.match(
     permissionsSource,


### PR DESCRIPTION
## Summary
- Add Codex model, reasoning, speed, and Git identity defaults to agents and expose them in factory agent settings.
- Add an agent selector before the model configuration on the new-worker composer; selecting an agent applies its defaults while leaving model configuration overrideable.
- Store the selected agent on newly-created workers and show that agent selector disabled on worker chat, since a worker's agent cannot change after creation.
- Move Codex auth out of the factory checkpoint path: worker sandboxes now install Codex auth from the linked agent when the sandbox is first created.
- Apply Git identity from the linked agent when set, falling back to the factory Git identity.
- Update the model dropdown so the lightning icon only appears filled for fast speed and the selected model label uses the full model name.

## Tests
- `npx --yes pnpm@latest check`
- `npx --yes pnpm@latest typecheck`
- `npx --yes pnpm@latest test:unit`