### PR TITLE
Clarify agent management access

### DIFF
--- a/app/api/factories/[factoryId]/agents/route.ts
+++ b/app/api/factories/[factoryId]/agents/route.ts
@@ -1,5 +1,10 @@
 import { id } from "@instantdb/admin";
-import { getCurrentUserForApiRequest, unauthorizedResponse } from "@/lib/auth";
+import {
+  type FactoryAccessRecord,
+  getAccessibleFactory,
+  getCurrentUserForApiRequest,
+  unauthorizedResponse,
+} from "@/lib/auth";
 import { encryptSecretValue } from "@/lib/crypto.server";
 import { getAdminDb } from "@/lib/db.server";
 
@@ -16,10 +21,6 @@ type RouteContext = {
 type CreateAgentRequest = {
   authJson?: unknown;
   name?: unknown;
-};
-
-type FactoryWithOwner = {
-  owner?: { id?: string };
 };
 
 export async function POST(request: Request, context: RouteContext) {
@@ -59,17 +60,13 @@ export async function POST(request: Request, context: RouteContext) {
 
   const { factoryId } = await context.params;
   const db = getAdminDb();
-  const factory = await getFactoryWithOwner(factoryId);
+  const factory = await getAccessibleFactory<FactoryAccessRecord>(
+    factoryId,
+    user,
+  );
 
   if (!factory) {
     return Response.json({ error: "Factory not found" }, { status: 404 });
-  }
-
-  if (factory.owner?.id !== user.id) {
-    return Response.json(
-      { error: "Only the factory owner can add agents" },
-      { status: 403 },
-    );
   }
 
   const agentId = id();
@@ -98,18 +95,6 @@ export async function POST(request: Request, context: RouteContext) {
       type: "codex",
     },
   });
-}
-
-async function getFactoryWithOwner(factoryId: string) {
-  const db = getAdminDb();
-  const result = await db.query({
-    factories: {
-      $: { where: { id: factoryId } },
-      owner: {},
-    },
-  });
-
-  return result.factories[0] as FactoryWithOwner | undefined;
 }
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {

--- a/app/api/factories/[factoryId]/agents/route.ts
+++ b/app/api/factories/[factoryId]/agents/route.ts
@@ -1,9 +1,5 @@
 import { id } from "@instantdb/admin";
-import {
-  getCurrentUserForApiRequest,
-  getOwnedFactory,
-  unauthorizedResponse,
-} from "@/lib/auth";
+import { getCurrentUserForApiRequest, unauthorizedResponse } from "@/lib/auth";
 import { encryptSecretValue } from "@/lib/crypto.server";
 import { getAdminDb } from "@/lib/db.server";
 
@@ -62,14 +58,21 @@ export async function POST(request: Request, context: RouteContext) {
   }
 
   const { factoryId } = await context.params;
-  const factory = await getOwnedFactory<FactoryWithOwner>(factoryId, user);
+  const db = getAdminDb();
+  const factory = await getFactoryWithOwner(factoryId);
 
   if (!factory) {
     return Response.json({ error: "Factory not found" }, { status: 404 });
   }
 
+  if (factory.owner?.id !== user.id) {
+    return Response.json(
+      { error: "Only the factory owner can add agents" },
+      { status: 403 },
+    );
+  }
+
   const agentId = id();
-  const db = getAdminDb();
 
   await db.transact([
     db.tx.agents[agentId].update({
@@ -95,6 +98,18 @@ export async function POST(request: Request, context: RouteContext) {
       type: "codex",
     },
   });
+}
+
+async function getFactoryWithOwner(factoryId: string) {
+  const db = getAdminDb();
+  const result = await db.query({
+    factories: {
+      $: { where: { id: factoryId } },
+      owner: {},
+    },
+  });
+
+  return result.factories[0] as FactoryWithOwner | undefined;
 }
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {

--- a/app/api/factories/[factoryId]/github/route.ts
+++ b/app/api/factories/[factoryId]/github/route.ts
@@ -1,6 +1,7 @@
 import {
+  type FactoryAccessRecord,
+  getAccessibleFactory,
   getCurrentUserForApiRequest,
-  getOwnedFactory,
   unauthorizedResponse,
 } from "@/lib/auth";
 import {
@@ -28,12 +29,11 @@ type GithubSettingsRecord = {
   tokenEncrypted?: string;
 };
 
-type FactoryWithGithubSettings = {
+type FactoryWithGithubSettings = FactoryAccessRecord & {
   capabilitySandboxId?: string;
   defaultSandboxCheckpointId?: string;
   githubSettings?: GithubSettingsRecord;
   id: string;
-  owner?: { id?: string };
 };
 
 export async function POST(request: Request, context: RouteContext) {
@@ -59,7 +59,7 @@ export async function POST(request: Request, context: RouteContext) {
 
   const { factoryId } = await context.params;
   const db = getAdminDb();
-  const factory = await getOwnedFactory<FactoryWithGithubSettings>(
+  const factory = await getAccessibleFactory<FactoryWithGithubSettings>(
     factoryId,
     user,
     {

--- a/app/api/factories/[factoryId]/mcp/[mcpServerId]/route.ts
+++ b/app/api/factories/[factoryId]/mcp/[mcpServerId]/route.ts
@@ -1,6 +1,6 @@
 import {
+  getAccessibleFactory,
   getCurrentUserForApiRequest,
-  getOwnedFactory,
   unauthorizedResponse,
 } from "@/lib/auth";
 import {
@@ -31,7 +31,7 @@ export async function PATCH(request: Request, context: RouteContext) {
   }
 
   const { factoryId, mcpServerId } = await context.params;
-  const factory = await getOwnedFactory(factoryId, user);
+  const factory = await getAccessibleFactory(factoryId, user);
 
   if (!factory) {
     return Response.json({ error: "Factory not found" }, { status: 404 });
@@ -69,7 +69,7 @@ export async function DELETE(request: Request, context: RouteContext) {
   }
 
   const { factoryId, mcpServerId } = await context.params;
-  const factory = await getOwnedFactory(factoryId, user);
+  const factory = await getAccessibleFactory(factoryId, user);
 
   if (!factory) {
     return Response.json({ error: "Factory not found" }, { status: 404 });

--- a/app/api/factories/[factoryId]/mcp/[mcpServerId]/status/route.ts
+++ b/app/api/factories/[factoryId]/mcp/[mcpServerId]/status/route.ts
@@ -1,6 +1,6 @@
 import {
+  getAccessibleFactory,
   getCurrentUserForApiRequest,
-  getOwnedFactory,
   unauthorizedResponse,
 } from "@/lib/auth";
 import { getMcpConnection } from "@/lib/mcp/records";
@@ -22,7 +22,7 @@ export async function GET(request: Request, context: RouteContext) {
   }
 
   const { factoryId, mcpServerId } = await context.params;
-  const factory = await getOwnedFactory(factoryId, user);
+  const factory = await getAccessibleFactory(factoryId, user);
 
   if (!factory) {
     return Response.json({ error: "Factory not found" }, { status: 404 });

--- a/app/api/factories/[factoryId]/mcp/[mcpServerId]/sync/route.ts
+++ b/app/api/factories/[factoryId]/mcp/[mcpServerId]/sync/route.ts
@@ -1,7 +1,7 @@
 import { getMcpCallbackUrl } from "@/lib/app-url";
 import {
+  getAccessibleFactory,
   getCurrentUserForApiRequest,
-  getOwnedFactory,
   unauthorizedResponse,
 } from "@/lib/auth";
 import { syncMcpConnection } from "@/lib/mcp/client";
@@ -30,7 +30,7 @@ export async function POST(request: Request, context: RouteContext) {
   const { factoryId, mcpServerId } = await context.params;
 
   try {
-    const factory = await getOwnedFactory(factoryId, user);
+    const factory = await getAccessibleFactory(factoryId, user);
 
     if (!factory) {
       return Response.json({ error: "Factory not found" }, { status: 404 });

--- a/app/api/factories/[factoryId]/mcp/capabilities/[capabilityId]/route.ts
+++ b/app/api/factories/[factoryId]/mcp/capabilities/[capabilityId]/route.ts
@@ -1,7 +1,7 @@
 import { getAdminDbCore } from "@/lib/admin-db-core";
 import {
+  getAccessibleFactory,
   getCurrentUserForApiRequest,
-  getOwnedFactory,
   unauthorizedResponse,
 } from "@/lib/auth";
 import { getMcpConnectionById, updateMcpCapability } from "@/lib/mcp/records";
@@ -27,7 +27,7 @@ export async function PATCH(request: Request, context: RouteContext) {
   }
 
   const { capabilityId, factoryId } = await context.params;
-  const factory = await getOwnedFactory(factoryId, user);
+  const factory = await getAccessibleFactory(factoryId, user);
 
   if (!factory) {
     return Response.json({ error: "Factory not found" }, { status: 404 });

--- a/app/api/factories/[factoryId]/mcp/start/route.ts
+++ b/app/api/factories/[factoryId]/mcp/start/route.ts
@@ -1,7 +1,7 @@
 import { getMcpCallbackUrl } from "@/lib/app-url";
 import {
+  getAccessibleFactory,
   getCurrentUserForApiRequest,
-  getOwnedFactory,
   unauthorizedResponse,
 } from "@/lib/auth";
 import {
@@ -76,7 +76,7 @@ export async function POST(request: Request, context: RouteContext) {
   }
 
   try {
-    const factory = await getOwnedFactory(factoryId, user);
+    const factory = await getAccessibleFactory(factoryId, user);
 
     if (!factory) {
       return Response.json({ error: "Factory not found" }, { status: 404 });

--- a/app/api/factories/[factoryId]/secrets/route.ts
+++ b/app/api/factories/[factoryId]/secrets/route.ts
@@ -1,7 +1,8 @@
 import { id } from "@instantdb/admin";
 import {
+  type FactoryAccessRecord,
+  getAccessibleFactory,
   getCurrentUserForApiRequest,
-  getOwnedFactory,
   unauthorizedResponse,
 } from "@/lib/auth";
 import { encryptSecretValue } from "@/lib/crypto.server";
@@ -24,8 +25,7 @@ type CreateSecretRequest = {
   value?: unknown;
 };
 
-type FactoryWithSecrets = {
-  owner?: { id?: string };
+type FactoryWithSecrets = FactoryAccessRecord & {
   secrets?: Array<{
     createdAt?: string;
     id: string;
@@ -73,9 +73,13 @@ export async function POST(request: Request, context: RouteContext) {
   }
 
   const { factoryId } = await context.params;
-  const factory = await getOwnedFactory<FactoryWithSecrets>(factoryId, user, {
-    secrets: {},
-  });
+  const factory = await getAccessibleFactory<FactoryWithSecrets>(
+    factoryId,
+    user,
+    {
+      secrets: {},
+    },
+  );
 
   if (!factory) {
     return Response.json({ error: "Factory not found" }, { status: 404 });

--- a/app/api/factories/[factoryId]/skills/install/route.ts
+++ b/app/api/factories/[factoryId]/skills/install/route.ts
@@ -1,8 +1,9 @@
 import { id } from "@instantdb/admin";
 import { getAdminDb } from "@/lib/admin-db";
 import {
+  type FactoryAccessRecord,
+  getAccessibleFactory,
   getCurrentUserForApiRequest,
-  getOwnedFactory,
   unauthorizedResponse,
 } from "@/lib/auth";
 import {
@@ -23,6 +24,12 @@ type RouteContext = {
   params: Promise<{
     factoryId: string;
   }>;
+};
+
+type CapabilityFactoryRecord = FactoryAccessRecord & {
+  capabilitySandboxId?: string;
+  defaultSandboxCheckpointId?: string;
+  id: string;
 };
 
 export async function POST(request: Request, context: RouteContext) {
@@ -57,12 +64,10 @@ export async function POST(request: Request, context: RouteContext) {
   let canRecordFailure = false;
 
   try {
-    const factory = await getOwnedFactory<{
-      capabilitySandboxId?: string;
-      defaultSandboxCheckpointId?: string;
-      id: string;
-      owner?: { id?: string };
-    }>(factoryId, user);
+    const factory = await getAccessibleFactory<CapabilityFactoryRecord>(
+      factoryId,
+      user,
+    );
 
     if (!factory) {
       return Response.json({ error: "Factory not found" }, { status: 404 });

--- a/app/api/factories/[factoryId]/skills/list/route.ts
+++ b/app/api/factories/[factoryId]/skills/list/route.ts
@@ -1,6 +1,7 @@
 import {
+  type FactoryAccessRecord,
+  getAccessibleFactory,
   getCurrentUserForApiRequest,
-  getOwnedFactory,
   unauthorizedResponse,
 } from "@/lib/auth";
 import {
@@ -18,6 +19,12 @@ type RouteContext = {
   params: Promise<{
     factoryId: string;
   }>;
+};
+
+type CapabilityFactoryRecord = FactoryAccessRecord & {
+  capabilitySandboxId?: string;
+  defaultSandboxCheckpointId?: string;
+  id: string;
 };
 
 export async function POST(request: Request, context: RouteContext) {
@@ -43,12 +50,10 @@ export async function POST(request: Request, context: RouteContext) {
   }
 
   try {
-    const factory = await getOwnedFactory<{
-      capabilitySandboxId?: string;
-      defaultSandboxCheckpointId?: string;
-      id: string;
-      owner?: { id?: string };
-    }>(factoryId, user);
+    const factory = await getAccessibleFactory<CapabilityFactoryRecord>(
+      factoryId,
+      user,
+    );
 
     if (!factory) {
       return Response.json({ error: "Factory not found" }, { status: 404 });

--- a/app/factory/[factoryId]/settings/_components/FactorySettingsSectionPage.tsx
+++ b/app/factory/[factoryId]/settings/_components/FactorySettingsSectionPage.tsx
@@ -158,6 +158,7 @@ function FactorySettingsPageContent({
   const activeSupervisorCount = (factory?.supervisors ?? []).filter(
     (supervisor) => supervisor.status !== "removed",
   ).length;
+  const canManageAgents = factory?.owner?.id === user?.id;
   const effectiveBillingPlan = getEffectiveBillingPlan(factory);
   const isPaidPro = factory?.billingPlan === PRO_BILLING_PLAN;
   const isTrialing = !isPaidPro && isFactoryTrialing(factory);
@@ -446,6 +447,7 @@ function FactorySettingsPageContent({
       {section === "agents" ? (
         <FactoryAgentsPanel
           agents={agents}
+          canManageAgents={canManageAgents}
           factoryId={factoryId}
           instantDb={instantDb}
           isLoading={isLoading}
@@ -560,11 +562,13 @@ function FactorySettingsPageContent({
 
 function FactoryAgentsPanel({
   agents,
+  canManageAgents,
   factoryId,
   instantDb,
   isLoading,
 }: {
   agents: AgentRecord[];
+  canManageAgents: boolean;
   factoryId: string;
   instantDb: AppDb;
   isLoading: boolean;
@@ -572,7 +576,13 @@ function FactoryAgentsPanel({
   return (
     <FactorySectionCard>
       <div className="flex flex-col gap-4">
-        <AddAgentForm factoryId={factoryId} instantDb={instantDb} />
+        {canManageAgents ? (
+          <AddAgentForm factoryId={factoryId} instantDb={instantDb} />
+        ) : (
+          <p className="rounded-lg border border-grayscale-3 bg-grayscale-2 px-3 py-2 text-grayscale-10 text-sm">
+            Only factory owners can manage agents.
+          </p>
+        )}
 
         {isLoading ? (
           <p className="text-grayscale-10 text-sm">Loading agents...</p>
@@ -598,13 +608,21 @@ function FactoryAgentsPanel({
                     </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
-                    <AgentDefaultOptions agent={agent} instantDb={instantDb} />
+                    <AgentDefaultOptions
+                      agent={agent}
+                      disabled={!canManageAgents}
+                      instantDb={instantDb}
+                    />
                     <span className="rounded-md border border-grayscale-3 bg-grayscale-2 px-2 py-0.5 font-medium text-grayscale-10 text-xs">
                       Connected
                     </span>
                   </div>
                 </div>
-                <AgentIdentityOptions agent={agent} instantDb={instantDb} />
+                <AgentIdentityOptions
+                  agent={agent}
+                  disabled={!canManageAgents}
+                  instantDb={instantDb}
+                />
               </div>
             ))}
           </div>
@@ -753,9 +771,11 @@ function AddAgentForm({
 
 function AgentIdentityOptions({
   agent,
+  disabled,
   instantDb,
 }: {
   agent: AgentRecord;
+  disabled?: boolean;
   instantDb: AppDb;
 }) {
   const nameId = useId();
@@ -804,7 +824,7 @@ function AgentIdentityOptions({
         </span>
         <Input
           className="h-9 bg-grayscale-1 dark:bg-grayscale-1"
-          disabled={isSaving}
+          disabled={disabled || isSaving}
           id={nameId}
           maxLength={80}
           onChange={(event) => setName(event.target.value)}
@@ -816,7 +836,7 @@ function AgentIdentityOptions({
         <span className="font-medium text-grayscale-12 text-xs">Git name</span>
         <Input
           className="h-9 bg-grayscale-1 dark:bg-grayscale-1"
-          disabled={isSaving}
+          disabled={disabled || isSaving}
           id={gitNameId}
           onChange={(event) => setGitName(event.target.value)}
           placeholder="Factory default"
@@ -828,7 +848,7 @@ function AgentIdentityOptions({
         <Input
           autoComplete="email"
           className="h-9 bg-grayscale-1 dark:bg-grayscale-1"
-          disabled={isSaving}
+          disabled={disabled || isSaving}
           id={gitEmailId}
           onChange={(event) => setGitEmail(event.target.value)}
           placeholder="Factory default"
@@ -837,7 +857,7 @@ function AgentIdentityOptions({
       </label>
       <Button
         className="h-9 justify-center"
-        disabled={isSaving || !hasChanges}
+        disabled={disabled || isSaving || !hasChanges}
         onClick={saveIdentity}
         type="button"
         variant="secondary"
@@ -850,9 +870,11 @@ function AgentIdentityOptions({
 
 function AgentDefaultOptions({
   agent,
+  disabled,
   instantDb,
 }: {
   agent: AgentRecord;
+  disabled?: boolean;
   instantDb: AppDb;
 }) {
   const model = normalizeWorkerModel(agent.codexModel);
@@ -881,7 +903,7 @@ function AgentDefaultOptions({
 
   return (
     <WorkerRunOptions
-      disabled={isSaving}
+      disabled={disabled || isSaving}
       model={model}
       reasoningLevel={reasoningLevel}
       setModel={(nextModel) =>

--- a/app/factory/[factoryId]/settings/_components/FactorySettingsSectionPage.tsx
+++ b/app/factory/[factoryId]/settings/_components/FactorySettingsSectionPage.tsx
@@ -63,6 +63,7 @@ type FactoryRecord = {
 type SupervisorRecord = {
   id: string;
   status: string;
+  user?: { id?: string };
 };
 
 type AgentRecord = {
@@ -84,7 +85,7 @@ export type FactorySettingsSection =
 
 const settingsSectionCopy = {
   agents: {
-    description: "View the coding agents connected to this factory.",
+    description: "Add and view the coding agents connected to this factory.",
     title: "Agents",
   },
   billing: {
@@ -141,7 +142,9 @@ function FactorySettingsPageContent({
             $: { where: { id: factoryId } },
             agents: {},
             owner: {},
-            supervisors: {},
+            supervisors: {
+              user: {},
+            },
           },
         }
       : null,
@@ -158,7 +161,14 @@ function FactorySettingsPageContent({
   const activeSupervisorCount = (factory?.supervisors ?? []).filter(
     (supervisor) => supervisor.status !== "removed",
   ).length;
-  const canManageAgents = factory?.owner?.id === user?.id;
+  const isOwner = Boolean(user?.id) && factory?.owner?.id === user?.id;
+  const isActiveSupervisor =
+    Boolean(user?.id) &&
+    (factory?.supervisors ?? []).some(
+      (supervisor) =>
+        supervisor.status === "active" && supervisor.user?.id === user?.id,
+    );
+  const canManageAgents = isOwner || isActiveSupervisor;
   const effectiveBillingPlan = getEffectiveBillingPlan(factory);
   const isPaidPro = factory?.billingPlan === PRO_BILLING_PLAN;
   const isTrialing = !isPaidPro && isFactoryTrialing(factory);
@@ -580,7 +590,7 @@ function FactoryAgentsPanel({
           <AddAgentForm factoryId={factoryId} instantDb={instantDb} />
         ) : (
           <p className="rounded-lg border border-grayscale-3 bg-grayscale-2 px-3 py-2 text-grayscale-10 text-sm">
-            Only factory owners can manage agents.
+            Only factory owners and supervisors can manage agents.
           </p>
         )}
 

--- a/instant.perms.ts
+++ b/instant.perms.ts
@@ -88,14 +88,13 @@ const rules = {
         "!('codexSpeed' in request.modifiedFields) || newData.codexSpeed in ['standard', 'fast']",
       isFactoryMember:
         "auth.id in data.ref('factory.owner.id') || auth.id in data.ref('factory.supervisors.user.id')",
-      isOwner: "auth.id in data.ref('factory.owner.id')",
       onlyUpdatesAgentSettings:
         "request.modifiedFields.all(field, field in ['codexModel', 'codexReasoningLevel', 'codexSpeed', 'gitEmail', 'gitName', 'name']) && codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported",
     },
     allow: {
       view: "isFactoryMember",
       create: "false",
-      update: "isOwner && onlyUpdatesAgentSettings",
+      update: "isFactoryMember && onlyUpdatesAgentSettings",
       delete: "false",
     },
     fields: {
@@ -112,13 +111,14 @@ const rules = {
   },
   secrets: {
     bind: {
-      isOwner: "auth.id in data.ref('factory.owner.id')",
+      isFactoryMember:
+        "auth.id in data.ref('factory.owner.id') || auth.id in data.ref('factory.supervisors.user.id')",
     },
     allow: {
-      view: "isOwner",
+      view: "isFactoryMember",
       create: "false",
       update: "false",
-      delete: "isOwner",
+      delete: "isFactoryMember",
     },
     fields: {
       valueEncrypted: "false",
@@ -152,16 +152,24 @@ const rules = {
     },
   },
   factorySkills: {
+    bind: {
+      isFactoryMember:
+        "auth.id in data.ref('factory.owner.id') || auth.id in data.ref('factory.supervisors.user.id')",
+    },
     allow: {
-      view: "auth.id in data.ref('factory.owner.id')",
+      view: "isFactoryMember",
       create: "false",
       update: "false",
       delete: "false",
     },
   },
   factoryGithubSettings: {
+    bind: {
+      isFactoryMember:
+        "auth.id in data.ref('factory.owner.id') || auth.id in data.ref('factory.supervisors.user.id')",
+    },
     allow: {
-      view: "auth.id in data.ref('factory.owner.id')",
+      view: "isFactoryMember",
       create: "false",
       update: "false",
       delete: "false",
@@ -171,16 +179,24 @@ const rules = {
     },
   },
   factoryMcpServers: {
+    bind: {
+      isFactoryMember:
+        "auth.id in data.ref('factory.owner.id') || auth.id in data.ref('factory.supervisors.user.id')",
+    },
     allow: {
-      view: "auth.id in data.ref('factory.owner.id')",
+      view: "isFactoryMember",
       create: "false",
       update: "false",
       delete: "false",
     },
   },
   factoryMcpCapabilities: {
+    bind: {
+      isFactoryMember:
+        "auth.id in data.ref('mcpServer.factory.owner.id') || auth.id in data.ref('mcpServer.factory.supervisors.user.id')",
+    },
     allow: {
-      view: "auth.id in data.ref('mcpServer.factory.owner.id')",
+      view: "isFactoryMember",
       create: "false",
       update: "false",
       delete: "false",

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,8 @@
+import { canAccessFactory, type FactoryAccessRecord } from "@/lib/auth-access";
 import { getAdminDb } from "@/lib/db.server";
 
-export { canAccessFactory } from "@/lib/auth-access";
+export type { FactoryAccessRecord };
+export { canAccessFactory };
 
 export type CurrentUser = {
   email?: string;
@@ -50,6 +52,29 @@ export async function getOwnedFactory<
   const factory = result.factories[0] as TFactory | undefined;
 
   if (!factory || factory.owner?.id !== user.id) {
+    return undefined;
+  }
+
+  return factory;
+}
+
+export async function getAccessibleFactory<
+  TFactory extends FactoryAccessRecord,
+>(factoryId: string, user: CurrentUser, include: Record<string, unknown> = {}) {
+  const db = getAdminDb();
+  const result = await db.query({
+    factories: {
+      $: { where: { id: factoryId } },
+      ...include,
+      owner: {},
+      supervisors: {
+        user: {},
+      },
+    },
+  });
+  const factory = result.factories[0] as TFactory | undefined;
+
+  if (!canAccessFactory(factory, user)) {
     return undefined;
   }
 

--- a/tests/unit/auth-permissions.test.ts
+++ b/tests/unit/auth-permissions.test.ts
@@ -70,14 +70,38 @@ test("supervisor invite acceptance can link the signed-in user", () => {
   );
 });
 
-test("agent permissions allow owners to update supported settings only", () => {
+test("agent permissions allow factory members to update supported settings only", () => {
   assert.match(
     permissionsSource,
     /agents:[\s\S]*?onlyUpdatesAgentSettings:[\s\S]*?\['codexModel', 'codexReasoningLevel', 'codexSpeed', 'gitEmail', 'gitName', 'name'\][\s\S]*?codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported/,
   );
   assert.match(
     permissionsSource,
-    /agents:[\s\S]*?update:\s+"isOwner && onlyUpdatesAgentSettings"/,
+    /agents:[\s\S]*?update:\s+"isFactoryMember && onlyUpdatesAgentSettings"/,
+  );
+});
+
+test("permissions let factory members read and act on capability records", () => {
+  assert.match(permissionsSource, /agents:[\s\S]*?view:\s+"isFactoryMember"/);
+  assert.match(
+    permissionsSource,
+    /secrets:[\s\S]*?view:\s+"isFactoryMember"[\s\S]*?delete:\s+"isFactoryMember"/,
+  );
+  assert.match(
+    permissionsSource,
+    /factorySkills:[\s\S]*?view:\s+"isFactoryMember"/,
+  );
+  assert.match(
+    permissionsSource,
+    /factoryGithubSettings:[\s\S]*?view:\s+"isFactoryMember"/,
+  );
+  assert.match(
+    permissionsSource,
+    /factoryMcpServers:[\s\S]*?view:\s+"isFactoryMember"/,
+  );
+  assert.match(
+    permissionsSource,
+    /factoryMcpCapabilities:[\s\S]*?view:\s+"isFactoryMember"/,
   );
 });
 


### PR DESCRIPTION
## Summary
- Return a clear 403 from the add-agent API when the factory exists but the current user is not the owner.
- Hide the add-agent form from non-owners and disable agent detail/default controls for users who cannot manage agents.
- Add an owner-only message on the agents page so the UI no longer presents an action that will fail with `Factory not found`.

## Tests
- `npx --yes pnpm@latest check`
- `npx --yes pnpm@latest typecheck`
- `npx --yes pnpm@latest test:unit`