### PR TITLE
Use Codex access tokens for agents

### DIFF
--- a/app/api/factories/[factoryId]/agents/[agentId]/route.ts
+++ b/app/api/factories/[factoryId]/agents/[agentId]/route.ts
@@ -1,0 +1,87 @@
+import {
+  type FactoryAccessRecord,
+  getAccessibleFactory,
+  getCurrentUserForApiRequest,
+  unauthorizedResponse,
+} from "@/lib/auth";
+import { encryptSecretValue } from "@/lib/crypto.server";
+import { getAdminDb } from "@/lib/db.server";
+
+export const runtime = "nodejs";
+
+type AgentRecord = {
+  id: string;
+};
+
+type FactoryWithAgents = FactoryAccessRecord & {
+  agents?: AgentRecord[];
+};
+
+type RouteContext = {
+  params: Promise<{
+    agentId: string;
+    factoryId: string;
+  }>;
+};
+
+type UpdateAgentRequest = {
+  accessToken?: unknown;
+};
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const user = await getCurrentUserForApiRequest(request);
+
+  if (!user) {
+    return unauthorizedResponse();
+  }
+
+  let body: UpdateAgentRequest;
+
+  try {
+    body = (await request.json()) as UpdateAgentRequest;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const accessToken = parseCodexAccessToken(body.accessToken);
+
+  if (!accessToken) {
+    return Response.json(
+      { error: "Codex access token is required" },
+      { status: 400 },
+    );
+  }
+
+  const { agentId, factoryId } = await context.params;
+  const factory = await getAccessibleFactory<FactoryWithAgents>(
+    factoryId,
+    user,
+    {
+      agents: {},
+    },
+  );
+
+  if (!factory) {
+    return Response.json({ error: "Factory not found" }, { status: 404 });
+  }
+
+  const agent = factory.agents?.find((candidate) => candidate.id === agentId);
+
+  if (!agent) {
+    return Response.json({ error: "Agent not found" }, { status: 404 });
+  }
+
+  const db = getAdminDb();
+
+  await db.transact(
+    db.tx.agents[agent.id].update({
+      authEncrypted: encryptSecretValue(accessToken),
+    }),
+  );
+
+  return Response.json({ ok: true });
+}
+
+function parseCodexAccessToken(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}

--- a/app/api/factories/[factoryId]/agents/route.ts
+++ b/app/api/factories/[factoryId]/agents/route.ts
@@ -19,7 +19,7 @@ type RouteContext = {
 };
 
 type CreateAgentRequest = {
-  authJson?: unknown;
+  accessToken?: unknown;
   name?: unknown;
 };
 
@@ -51,9 +51,11 @@ export async function POST(request: Request, context: RouteContext) {
     );
   }
 
-  if (!isJsonObject(body.authJson)) {
+  const accessToken = parseCodexAccessToken(body.accessToken);
+
+  if (!accessToken) {
     return Response.json(
-      { error: "Codex auth JSON file is required" },
+      { error: "Codex access token is required" },
       { status: 400 },
     );
   }
@@ -73,7 +75,7 @@ export async function POST(request: Request, context: RouteContext) {
 
   await db.transact([
     db.tx.agents[agentId].update({
-      authEncrypted: encryptSecretValue(body.authJson),
+      authEncrypted: encryptSecretValue(accessToken),
       codexModel: "gpt-5.5",
       codexReasoningLevel: "medium",
       codexSpeed: "standard",
@@ -97,6 +99,6 @@ export async function POST(request: Request, context: RouteContext) {
   });
 }
 
-function isJsonObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+function parseCodexAccessToken(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }

--- a/app/api/factories/route.ts
+++ b/app/api/factories/route.ts
@@ -12,7 +12,7 @@ export const runtime = "nodejs";
 
 type CreateFactoryRequest = {
   codexAgent?: {
-    authJson?: unknown;
+    accessToken?: unknown;
     enabled?: boolean;
   };
   github?: unknown;
@@ -49,12 +49,14 @@ export async function POST(request: Request) {
   const now = new Date();
   const nowIso = now.toISOString();
   const shouldCreateCodexAgent = body.codexAgent?.enabled === true;
-  const codexAuthJson =
-    shouldCreateCodexAgent && body.codexAgent ? body.codexAgent.authJson : null;
+  const codexAccessToken =
+    shouldCreateCodexAgent && body.codexAgent
+      ? parseCodexAccessToken(body.codexAgent.accessToken)
+      : null;
 
-  if (shouldCreateCodexAgent && !isJsonObject(codexAuthJson)) {
+  if (shouldCreateCodexAgent && !codexAccessToken) {
     return Response.json(
-      { error: "Codex auth JSON file is required" },
+      { error: "Codex access token is required" },
       { status: 400 },
     );
   }
@@ -113,7 +115,7 @@ export async function POST(request: Request) {
       ? [
           ...factoryTransactions,
           db.tx.agents[agentId].update({
-            authEncrypted: encryptSecretValue(codexAuthJson),
+            authEncrypted: encryptSecretValue(codexAccessToken),
             codexModel: "gpt-5.5",
             codexReasoningLevel: "medium",
             codexSpeed: "standard",
@@ -154,6 +156,6 @@ export async function POST(request: Request) {
   }
 }
 
-function isJsonObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+function parseCodexAccessToken(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }

--- a/app/factories/new/page.tsx
+++ b/app/factories/new/page.tsx
@@ -6,7 +6,6 @@ import {
   BuildingsIcon,
   CheckIcon,
   CircleNotchIcon,
-  CopyIcon,
   CpuIcon,
   FolderSimpleIcon,
   GithubLogoIcon,
@@ -97,7 +96,7 @@ function NewFactoryWizard({ instantDb }: { instantDb: AppDb }) {
   const [githubRepositories, setGithubRepositories] = useState<
     GithubRepositoryRow[]
   >([]);
-  const [codexAuthJsonText, setCodexAuthJsonText] = useState("");
+  const [codexAccessToken, setCodexAccessToken] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -180,10 +179,10 @@ function NewFactoryWizard({ instantDb }: { instantDb: AppDb }) {
       return;
     }
 
-    const parsedCodexAuthJson = parseCodexAuthJson(codexAuthJsonText);
+    const parsedCodexAccessToken = parseCodexAccessToken(codexAccessToken);
 
-    if ("error" in parsedCodexAuthJson) {
-      setError(parsedCodexAuthJson.error);
+    if ("error" in parsedCodexAccessToken) {
+      setError(parsedCodexAccessToken.error);
       return;
     }
     setIsSaving(true);
@@ -197,7 +196,7 @@ function NewFactoryWizard({ instantDb }: { instantDb: AppDb }) {
         },
         body: JSON.stringify({
           codexAgent: {
-            authJson: parsedCodexAuthJson.authJson,
+            accessToken: parsedCodexAccessToken.accessToken,
             enabled: true,
           },
           github: {
@@ -320,7 +319,7 @@ function NewFactoryWizard({ instantDb }: { instantDb: AppDb }) {
 
           {step === "agent" ? (
             <AgentStep
-              codexAuthJsonText={codexAuthJsonText}
+              codexAccessToken={codexAccessToken}
               error={error}
               factoryName={trimmedName || "Untitled factory"}
               filledRepositoryCount={filledRepositories.length}
@@ -330,7 +329,7 @@ function NewFactoryWizard({ instantDb }: { instantDb: AppDb }) {
               isSaving={isSaving}
               onBack={() => advanceToStep("github")}
               onSubmit={createFactory}
-              setCodexAuthJsonText={setCodexAuthJsonText}
+              setCodexAccessToken={setCodexAccessToken}
             />
           ) : null}
         </div>
@@ -813,7 +812,7 @@ function RepositoryRow({
 }
 
 function AgentStep({
-  codexAuthJsonText,
+  codexAccessToken,
   error,
   factoryName,
   filledRepositoryCount,
@@ -823,9 +822,9 @@ function AgentStep({
   isSaving,
   onBack,
   onSubmit,
-  setCodexAuthJsonText,
+  setCodexAccessToken,
 }: {
-  codexAuthJsonText: string;
+  codexAccessToken: string;
   error: string | null;
   factoryName: string;
   filledRepositoryCount: number;
@@ -835,31 +834,9 @@ function AgentStep({
   isSaving: boolean;
   onBack: () => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
-  setCodexAuthJsonText: Dispatch<SetStateAction<string>>;
+  setCodexAccessToken: Dispatch<SetStateAction<string>>;
 }) {
-  const authJsonId = useId();
-  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
-    "idle",
-  );
-
-  useEffect(() => {
-    if (copyState === "idle") {
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => setCopyState("idle"), 2000);
-
-    return () => window.clearTimeout(timeoutId);
-  }, [copyState]);
-
-  async function copyCommand() {
-    try {
-      await navigator.clipboard.writeText("pbcopy < ~/.codex/auth.json");
-      setCopyState("copied");
-    } catch {
-      setCopyState("error");
-    }
-  }
+  const accessTokenId = useId();
 
   const githubSummary =
     filledRepositoryCount > 0
@@ -881,76 +858,33 @@ function AgentStep({
 
         <FieldGroup
           description={
-            "Paste auth.json from ~/.codex so the agent can sign into Codex from this factory's sandboxes."
+            "Paste a Codex access token so the agent can run Codex non-interactively in this factory's sandboxes."
           }
-          title="Codex auth"
+          title="Codex access token"
         >
-          <div className="flex flex-col gap-3">
-            <div className="rounded-lg border border-grayscale-3 bg-grayscale-2 p-3 dark:bg-grayscale-3/40">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="font-medium text-grayscale-12 text-sm">
-                    Copy from this machine
-                  </p>
-                  <p className="text-grayscale-10 text-xs">
-                    Runs locally and copies your existing Codex auth into the
-                    clipboard.
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={copyCommand}
-                  disabled={isSaving}
-                  className="flex shrink-0 items-center gap-1.5 rounded-md border border-grayscale-4 bg-grayscale-1 px-2 py-1 font-medium text-grayscale-11 text-xs transition-colors hover:border-grayscale-6 hover:text-grayscale-12 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-grayscale-2"
-                >
-                  {copyState === "copied" ? (
-                    <>
-                      <CheckIcon size={12} weight="bold" aria-hidden="true" />
-                      Copied
-                    </>
-                  ) : copyState === "error" ? (
-                    <>
-                      <WarningCircleIcon
-                        size={12}
-                        weight="bold"
-                        aria-hidden="true"
-                      />
-                      Try again
-                    </>
-                  ) : (
-                    <>
-                      <CopyIcon size={12} weight="bold" aria-hidden="true" />
-                      Copy
-                    </>
-                  )}
-                </button>
-              </div>
-              <code className="mt-2 block overflow-x-auto rounded-md bg-grayscale-1 px-3 py-2 font-mono text-grayscale-11 text-xs">
-                pbcopy &lt; ~/.codex/auth.json
-              </code>
-            </div>
-
-            <label className="flex flex-col gap-1.5" htmlFor={authJsonId}>
-              <span className="font-medium text-grayscale-12 text-sm">
-                Codex auth JSON
-              </span>
-              <textarea
-                id={authJsonId}
-                value={codexAuthJsonText}
-                onChange={(event) => setCodexAuthJsonText(event.target.value)}
-                placeholder='{"tokens":{}}'
-                autoComplete="off"
-                disabled={isSaving}
-                spellCheck={false}
-                required
-                className="min-h-48 w-full resize-y rounded-lg border border-grayscale-3 bg-grayscale-1 p-3 font-mono text-grayscale-12 text-xs outline-none transition-colors placeholder:text-grayscale-9 focus:border-accent-9 dark:bg-grayscale-1"
-              />
-              <span className="text-grayscale-10 text-xs">
-                Saved encrypted on the agent and copied as a file into the
-                default snapshot.
-              </span>
-            </label>
-          </div>
+          <label className="flex flex-col gap-1.5" htmlFor={accessTokenId}>
+            <span className="font-medium text-grayscale-12 text-sm">
+              Access token
+            </span>
+            <textarea
+              id={accessTokenId}
+              value={codexAccessToken}
+              onChange={(event) => setCodexAccessToken(event.target.value)}
+              placeholder="codex_access_token..."
+              autoComplete="off"
+              disabled={isSaving}
+              spellCheck={false}
+              required
+              className="min-h-32 w-full resize-y rounded-lg border border-grayscale-3 bg-grayscale-1 p-3 font-mono text-grayscale-12 text-xs outline-none transition-colors placeholder:text-grayscale-9 focus:border-accent-9 dark:bg-grayscale-1"
+            />
+            <span className="text-grayscale-10 text-xs">
+              Saved encrypted on the agent and passed to Codex as{" "}
+              <code className="rounded bg-grayscale-3 px-1 py-0.5 font-mono text-xs">
+                CODEX_ACCESS_TOKEN
+              </code>{" "}
+              for each run.
+            </span>
+          </label>
         </FieldGroup>
       </div>
       <StepFooter>
@@ -1118,28 +1052,16 @@ function extractRepoPathFromUrl(value: string): string {
   return segments.at(-1) ?? "";
 }
 
-function isJsonObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function parseCodexAuthJson(
+function parseCodexAccessToken(
   value: string,
-): { authJson: Record<string, unknown> } | { error: string } {
+): { accessToken: string } | { error: string } {
   const trimmedValue = value.trim();
 
   if (!trimmedValue) {
-    return { error: "Paste the Codex auth JSON before creating the factory." };
+    return {
+      error: "Paste the Codex access token before creating the factory.",
+    };
   }
 
-  try {
-    const parsed = JSON.parse(trimmedValue) as unknown;
-
-    if (!isJsonObject(parsed)) {
-      return { error: "Codex auth JSON must be a JSON object." };
-    }
-
-    return { authJson: parsed };
-  } catch {
-    return { error: "Codex auth JSON is not valid JSON." };
-  }
+  return { accessToken: trimmedValue };
 }

--- a/app/factories/new/page.tsx
+++ b/app/factories/new/page.tsx
@@ -78,7 +78,6 @@ const STEP_DEFINITIONS: readonly StepDefinition[] = [
     icon: CpuIcon,
     id: "agent",
     label: "Agent",
-    optional: true,
     title: "Add your first agent",
   },
 ] as const;
@@ -98,7 +97,6 @@ function NewFactoryWizard({ instantDb }: { instantDb: AppDb }) {
   const [githubRepositories, setGithubRepositories] = useState<
     GithubRepositoryRow[]
   >([]);
-  const [addCodexAgent, setAddCodexAgent] = useState(true);
   const [codexAuthJsonText, setCodexAuthJsonText] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -182,10 +180,7 @@ function NewFactoryWizard({ instantDb }: { instantDb: AppDb }) {
       return;
     }
 
-    const parsedCodexAuthJson = parseCodexAuthJson({
-      enabled: addCodexAgent,
-      value: codexAuthJsonText,
-    });
+    const parsedCodexAuthJson = parseCodexAuthJson(codexAuthJsonText);
 
     if ("error" in parsedCodexAuthJson) {
       setError(parsedCodexAuthJson.error);
@@ -203,7 +198,7 @@ function NewFactoryWizard({ instantDb }: { instantDb: AppDb }) {
         body: JSON.stringify({
           codexAgent: {
             authJson: parsedCodexAuthJson.authJson,
-            enabled: addCodexAgent,
+            enabled: true,
           },
           github: {
             gitEmail,
@@ -325,7 +320,6 @@ function NewFactoryWizard({ instantDb }: { instantDb: AppDb }) {
 
           {step === "agent" ? (
             <AgentStep
-              addCodexAgent={addCodexAgent}
               codexAuthJsonText={codexAuthJsonText}
               error={error}
               factoryName={trimmedName || "Untitled factory"}
@@ -336,7 +330,6 @@ function NewFactoryWizard({ instantDb }: { instantDb: AppDb }) {
               isSaving={isSaving}
               onBack={() => advanceToStep("github")}
               onSubmit={createFactory}
-              setAddCodexAgent={setAddCodexAgent}
               setCodexAuthJsonText={setCodexAuthJsonText}
             />
           ) : null}
@@ -820,7 +813,6 @@ function RepositoryRow({
 }
 
 function AgentStep({
-  addCodexAgent,
   codexAuthJsonText,
   error,
   factoryName,
@@ -831,10 +823,8 @@ function AgentStep({
   isSaving,
   onBack,
   onSubmit,
-  setAddCodexAgent,
   setCodexAuthJsonText,
 }: {
-  addCodexAgent: boolean;
   codexAuthJsonText: string;
   error: string | null;
   factoryName: string;
@@ -845,11 +835,9 @@ function AgentStep({
   isSaving: boolean;
   onBack: () => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
-  setAddCodexAgent: Dispatch<SetStateAction<boolean>>;
   setCodexAuthJsonText: Dispatch<SetStateAction<string>>;
 }) {
   const authJsonId = useId();
-  const toggleId = useId();
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
     "idle",
   );
@@ -888,138 +876,81 @@ function AgentStep({
         <SummaryCard>
           <SummaryRow label="Factory" value={factoryName} />
           <SummaryRow label="GitHub" value={githubSummary} />
-          <SummaryRow
-            label="Codex agent"
-            value={addCodexAgent ? "Will be added" : "Not now"}
-          />
+          <SummaryRow label="Codex agent" value="Will be added" />
         </SummaryCard>
 
-        <FieldGroup title="Codex agent">
-          <label
-            htmlFor={toggleId}
-            className={cn(
-              "flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors",
-              addCodexAgent
-                ? "border-accent-7 bg-accent-2"
-                : "border-grayscale-3 bg-grayscale-2 hover:border-grayscale-5 dark:bg-grayscale-3/40",
-            )}
-          >
-            <span className="relative mt-0.5 flex h-5 w-9 shrink-0 items-center">
-              <input
-                id={toggleId}
-                type="checkbox"
-                className="peer sr-only"
-                checked={addCodexAgent}
-                onChange={(event) => setAddCodexAgent(event.target.checked)}
-                disabled={isSaving}
-              />
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "absolute inset-0 rounded-full border transition-colors",
-                  addCodexAgent
-                    ? "border-accent-9 bg-accent-9"
-                    : "border-grayscale-5 bg-grayscale-4",
-                )}
-              />
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "absolute top-0.5 left-0.5 size-4 rounded-full bg-white shadow-sm transition-transform",
-                  addCodexAgent ? "translate-x-4" : "translate-x-0",
-                )}
-              />
-            </span>
-            <span className="flex min-w-0 flex-col gap-1">
-              <span className="font-medium text-grayscale-12 text-sm">
-                Add a Codex agent now
-              </span>
-              <span className="text-grayscale-11 text-sm">
-                Paste{" "}
-                <code className="rounded bg-grayscale-3 px-1 py-0.5 font-mono text-xs">
-                  auth.json
-                </code>{" "}
-                from{" "}
-                <code className="rounded bg-grayscale-3 px-1 py-0.5 font-mono text-xs">
-                  ~/.codex
-                </code>{" "}
-                so the agent can sign into Codex from this factory's sandboxes.
-              </span>
-            </span>
-          </label>
-
-          {addCodexAgent ? (
-            <div className="mt-3 flex flex-col gap-3">
-              <div className="rounded-lg border border-grayscale-3 bg-grayscale-2 p-3 dark:bg-grayscale-3/40">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="font-medium text-grayscale-12 text-sm">
-                      Copy from this machine
-                    </p>
-                    <p className="text-grayscale-10 text-xs">
-                      Runs locally and copies your existing Codex auth into the
-                      clipboard.
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={copyCommand}
-                    disabled={isSaving}
-                    className="flex shrink-0 items-center gap-1.5 rounded-md border border-grayscale-4 bg-grayscale-1 px-2 py-1 font-medium text-grayscale-11 text-xs transition-colors hover:border-grayscale-6 hover:text-grayscale-12 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-grayscale-2"
-                  >
-                    {copyState === "copied" ? (
-                      <>
-                        <CheckIcon size={12} weight="bold" aria-hidden="true" />
-                        Copied
-                      </>
-                    ) : copyState === "error" ? (
-                      <>
-                        <WarningCircleIcon
-                          size={12}
-                          weight="bold"
-                          aria-hidden="true"
-                        />
-                        Try again
-                      </>
-                    ) : (
-                      <>
-                        <CopyIcon size={12} weight="bold" aria-hidden="true" />
-                        Copy
-                      </>
-                    )}
-                  </button>
+        <FieldGroup
+          description={
+            "Paste auth.json from ~/.codex so the agent can sign into Codex from this factory's sandboxes."
+          }
+          title="Codex auth"
+        >
+          <div className="flex flex-col gap-3">
+            <div className="rounded-lg border border-grayscale-3 bg-grayscale-2 p-3 dark:bg-grayscale-3/40">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="font-medium text-grayscale-12 text-sm">
+                    Copy from this machine
+                  </p>
+                  <p className="text-grayscale-10 text-xs">
+                    Runs locally and copies your existing Codex auth into the
+                    clipboard.
+                  </p>
                 </div>
-                <code className="mt-2 block overflow-x-auto rounded-md bg-grayscale-1 px-3 py-2 font-mono text-grayscale-11 text-xs">
-                  pbcopy &lt; ~/.codex/auth.json
-                </code>
-              </div>
-
-              <label className="flex flex-col gap-1.5" htmlFor={authJsonId}>
-                <span className="font-medium text-grayscale-12 text-sm">
-                  Codex auth JSON
-                </span>
-                <textarea
-                  id={authJsonId}
-                  value={codexAuthJsonText}
-                  onChange={(event) => setCodexAuthJsonText(event.target.value)}
-                  placeholder='{"tokens":{}}'
-                  autoComplete="off"
+                <button
+                  type="button"
+                  onClick={copyCommand}
                   disabled={isSaving}
-                  spellCheck={false}
-                  className="min-h-48 w-full resize-y rounded-lg border border-grayscale-3 bg-grayscale-1 p-3 font-mono text-grayscale-12 text-xs outline-none transition-colors placeholder:text-grayscale-9 focus:border-accent-9 dark:bg-grayscale-1"
-                />
-                <span className="text-grayscale-10 text-xs">
-                  Saved encrypted on the agent and installed into worker
-                  sandboxes created with that agent.
-                </span>
-              </label>
+                  className="flex shrink-0 items-center gap-1.5 rounded-md border border-grayscale-4 bg-grayscale-1 px-2 py-1 font-medium text-grayscale-11 text-xs transition-colors hover:border-grayscale-6 hover:text-grayscale-12 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-grayscale-2"
+                >
+                  {copyState === "copied" ? (
+                    <>
+                      <CheckIcon size={12} weight="bold" aria-hidden="true" />
+                      Copied
+                    </>
+                  ) : copyState === "error" ? (
+                    <>
+                      <WarningCircleIcon
+                        size={12}
+                        weight="bold"
+                        aria-hidden="true"
+                      />
+                      Try again
+                    </>
+                  ) : (
+                    <>
+                      <CopyIcon size={12} weight="bold" aria-hidden="true" />
+                      Copy
+                    </>
+                  )}
+                </button>
+              </div>
+              <code className="mt-2 block overflow-x-auto rounded-md bg-grayscale-1 px-3 py-2 font-mono text-grayscale-11 text-xs">
+                pbcopy &lt; ~/.codex/auth.json
+              </code>
             </div>
-          ) : (
-            <p className="mt-3 rounded-lg border border-grayscale-3 border-dashed bg-grayscale-2 px-3 py-2 text-grayscale-11 text-xs dark:bg-grayscale-3/40">
-              Skipping for now. You can connect an agent any time from the
-              factory's agents settings.
-            </p>
-          )}
+
+            <label className="flex flex-col gap-1.5" htmlFor={authJsonId}>
+              <span className="font-medium text-grayscale-12 text-sm">
+                Codex auth JSON
+              </span>
+              <textarea
+                id={authJsonId}
+                value={codexAuthJsonText}
+                onChange={(event) => setCodexAuthJsonText(event.target.value)}
+                placeholder='{"tokens":{}}'
+                autoComplete="off"
+                disabled={isSaving}
+                spellCheck={false}
+                required
+                className="min-h-48 w-full resize-y rounded-lg border border-grayscale-3 bg-grayscale-1 p-3 font-mono text-grayscale-12 text-xs outline-none transition-colors placeholder:text-grayscale-9 focus:border-accent-9 dark:bg-grayscale-1"
+              />
+              <span className="text-grayscale-10 text-xs">
+                Saved encrypted on the agent and copied as a file into the
+                default snapshot.
+              </span>
+            </label>
+          </div>
         </FieldGroup>
       </div>
       <StepFooter>
@@ -1191,17 +1122,9 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function parseCodexAuthJson({
-  enabled,
-  value,
-}: {
-  enabled: boolean;
-  value: string;
-}): { authJson?: Record<string, unknown> } | { error: string } {
-  if (!enabled) {
-    return {};
-  }
-
+function parseCodexAuthJson(
+  value: string,
+): { authJson: Record<string, unknown> } | { error: string } {
   const trimmedValue = value.trim();
 
   if (!trimmedValue) {

--- a/app/factory/[factoryId]/settings/_components/FactorySettingsSectionPage.tsx
+++ b/app/factory/[factoryId]/settings/_components/FactorySettingsSectionPage.tsx
@@ -633,6 +633,12 @@ function FactoryAgentsPanel({
                   disabled={!canManageAgents}
                   instantDb={instantDb}
                 />
+                <AgentAccessTokenForm
+                  agent={agent}
+                  disabled={!canManageAgents}
+                  factoryId={factoryId}
+                  instantDb={instantDb}
+                />
               </div>
             ))}
           </div>
@@ -660,9 +666,9 @@ function AddAgentForm({
 }) {
   const { user } = instantDb.useAuth();
   const nameId = useId();
-  const authJsonId = useId();
+  const accessTokenId = useId();
   const [name, setName] = useState("");
-  const [authJsonText, setAuthJsonText] = useState("");
+  const [accessToken, setAccessToken] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -681,17 +687,10 @@ function AddAgentForm({
       return;
     }
 
-    let authJson: unknown;
+    const trimmedAccessToken = accessToken.trim();
 
-    try {
-      authJson = JSON.parse(authJsonText);
-    } catch {
-      setError("Codex auth JSON must be valid JSON.");
-      return;
-    }
-
-    if (!isJsonObject(authJson)) {
-      setError("Codex auth JSON must be a JSON object.");
+    if (!trimmedAccessToken) {
+      setError("Codex access token is required.");
       return;
     }
 
@@ -701,7 +700,7 @@ function AddAgentForm({
     try {
       const response = await fetch(`/api/factories/${factoryId}/agents`, {
         body: JSON.stringify({
-          authJson,
+          accessToken: trimmedAccessToken,
           name: trimmedName,
         }),
         headers: {
@@ -720,7 +719,7 @@ function AddAgentForm({
       }
 
       setName("");
-      setAuthJsonText("");
+      setAccessToken("");
     } finally {
       setIsSaving(false);
     }
@@ -746,19 +745,22 @@ function AddAgentForm({
             value={name}
           />
         </label>
-        <label className="flex min-w-0 flex-col gap-1.5" htmlFor={authJsonId}>
+        <label
+          className="flex min-w-0 flex-col gap-1.5"
+          htmlFor={accessTokenId}
+        >
           <span className="font-medium text-grayscale-12 text-xs">
-            Codex auth JSON
+            Codex access token
           </span>
           <textarea
             autoComplete="off"
             className="min-h-24 resize-y rounded-lg border border-grayscale-3 bg-grayscale-1 px-3 py-2 font-mono text-grayscale-12 text-xs outline-none placeholder:text-grayscale-9 focus:border-accent-9 dark:bg-grayscale-1"
             disabled={isSaving}
-            id={authJsonId}
-            onChange={(event) => setAuthJsonText(event.target.value)}
-            placeholder='{"tokens":{}}'
+            id={accessTokenId}
+            onChange={(event) => setAccessToken(event.target.value)}
+            placeholder="codex_access_token..."
             spellCheck={false}
-            value={authJsonText}
+            value={accessToken}
           />
         </label>
         <Button
@@ -878,6 +880,126 @@ function AgentIdentityOptions({
   );
 }
 
+function AgentAccessTokenForm({
+  agent,
+  disabled,
+  factoryId,
+  instantDb,
+}: {
+  agent: AgentRecord;
+  disabled?: boolean;
+  factoryId: string;
+  instantDb: AppDb;
+}) {
+  const { user } = instantDb.useAuth();
+  const accessTokenId = useId();
+  const [accessToken, setAccessToken] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<"idle" | "saving" | "saved">("idle");
+
+  const trimmedAccessToken = accessToken.trim();
+
+  async function updateAccessToken(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!trimmedAccessToken) {
+      setError("Codex access token is required.");
+      return;
+    }
+
+    if (!user?.refresh_token) {
+      setError("You must be signed in to update this agent.");
+      return;
+    }
+
+    setError(null);
+    setStatus("saving");
+
+    try {
+      const response = await fetch(
+        `/api/factories/${factoryId}/agents/${agent.id}`,
+        {
+          body: JSON.stringify({
+            accessToken: trimmedAccessToken,
+          }),
+          headers: {
+            authorization: `Bearer ${user.refresh_token}`,
+            "content-type": "application/json",
+          },
+          method: "PATCH",
+        },
+      );
+      const result = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
+
+      if (!response.ok) {
+        setError(result.error ?? "Access token could not be updated.");
+        setStatus("idle");
+        return;
+      }
+
+      setAccessToken("");
+      setStatus("saved");
+      window.setTimeout(() => setStatus("idle"), 2000);
+    } catch (updateError) {
+      console.error(updateError);
+      setError("Access token could not be updated.");
+      setStatus("idle");
+    }
+  }
+
+  return (
+    <form
+      className="grid gap-2 border-grayscale-3 border-t pt-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end"
+      onSubmit={updateAccessToken}
+    >
+      <label className="flex min-w-0 flex-col gap-1.5" htmlFor={accessTokenId}>
+        <span className="font-medium text-grayscale-12 text-xs">
+          Codex access token
+        </span>
+        <textarea
+          autoComplete="off"
+          className="min-h-20 resize-y rounded-lg border border-grayscale-3 bg-grayscale-1 px-3 py-2 font-mono text-grayscale-12 text-xs outline-none placeholder:text-grayscale-9 focus:border-accent-9 dark:bg-grayscale-1"
+          disabled={disabled || status === "saving"}
+          id={accessTokenId}
+          onChange={(event) => {
+            setAccessToken(event.target.value);
+            setError(null);
+            if (status === "saved") {
+              setStatus("idle");
+            }
+          }}
+          placeholder="Paste a new Codex access token"
+          spellCheck={false}
+          value={accessToken}
+        />
+        {error ? (
+          <span className="text-red-11 text-xs" role="alert">
+            {error}
+          </span>
+        ) : (
+          <span className="text-grayscale-10 text-xs">
+            Replaces the encrypted credential used for future runs.
+          </span>
+        )}
+      </label>
+      <Button
+        className="h-9 justify-center"
+        disabled={disabled || status === "saving" || !trimmedAccessToken}
+        type="submit"
+        variant="secondary"
+      >
+        {status === "saving"
+          ? "Updating..."
+          : status === "saved"
+            ? "Updated"
+            : "Update token"}
+      </Button>
+    </form>
+  );
+}
+
 function AgentDefaultOptions({
   agent,
   disabled,
@@ -955,10 +1077,6 @@ function formatAgentType(type?: string) {
 
 function getAgentDisplayName(agent: AgentRecord) {
   return agent.name?.trim() || formatAgentType(agent.type);
-}
-
-function isJsonObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function formatBillingDate(value: string) {

--- a/jobs/run-worker.ts
+++ b/jobs/run-worker.ts
@@ -71,6 +71,8 @@ type AgentRecord = {
   id: string;
 };
 
+type AgentCodexCredential = { accessToken: string } | { authJson: string };
+
 type SecretRecord = {
   name?: string;
   valueEncrypted?: string;
@@ -227,6 +229,9 @@ export const runWorkerTask = task({
         resumeCodexSession &&
         worker.status === "running" &&
         typeof worker.activePid === "number";
+      const codexCredential = worker.agent?.authEncrypted
+        ? getAgentCodexCredential(worker.agent)
+        : undefined;
 
       logTaskStep("info", "Sandbox ready", {
         resume: resumeCodexSession,
@@ -236,13 +241,17 @@ export const runWorkerTask = task({
         workerId: worker.id,
       });
 
-      if (!resumeCodexSession && worker.agent?.authEncrypted) {
+      if (
+        !resumeCodexSession &&
+        codexCredential &&
+        "authJson" in codexCredential
+      ) {
         await installCodexAuthOnSandbox({
-          codexAuthJson: getAgentCodexAuthJson(worker.agent),
+          codexAuthJson: codexCredential.authJson,
           sandbox,
         });
-        logTaskStep("info", "Agent Codex auth installed in worker sandbox", {
-          agentId: worker.agent.id,
+        logTaskStep("info", "Legacy agent Codex auth installed in sandbox", {
+          agentId: worker.agent?.id,
           sandboxId,
           workerId: worker.id,
         });
@@ -335,6 +344,10 @@ export const runWorkerTask = task({
       });
 
       const stream = await streamCodexExec({
+        codexAccessToken:
+          codexCredential && "accessToken" in codexCredential
+            ? codexCredential.accessToken
+            : undefined,
         imagePaths,
         mcpConfig,
         model: worker.codexModel,
@@ -525,14 +538,18 @@ async function getWorker(workerId: string) {
   return result.workers[0] as WorkerRecord | undefined;
 }
 
-function getAgentCodexAuthJson(agent: AgentRecord) {
-  const authJson = decryptSecretValue<unknown>(agent.authEncrypted);
+function getAgentCodexCredential(agent: AgentRecord): AgentCodexCredential {
+  const credential = decryptSecretValue<unknown>(agent.authEncrypted);
 
-  if (!isJsonObject(authJson)) {
-    throw new Error("Worker agent Codex auth is missing or invalid");
+  if (typeof credential === "string" && credential.trim()) {
+    return { accessToken: credential.trim() };
   }
 
-  return JSON.stringify(authJson, null, 2);
+  if (isJsonObject(credential)) {
+    return { authJson: JSON.stringify(credential, null, 2) };
+  }
+
+  throw new Error("Worker agent Codex credential is missing or invalid");
 }
 
 function getWorkerGitIdentity(worker: WorkerRecord) {

--- a/lib/codex/sandbox-auth.ts
+++ b/lib/codex/sandbox-auth.ts
@@ -180,6 +180,7 @@ export async function restoreCodexHome(sandbox: AppSandbox) {
 }
 
 export async function streamCodexExec({
+  codexAccessToken,
   imagePaths,
   mcpConfig,
   model = defaultWorkerModel,
@@ -193,6 +194,7 @@ export async function streamCodexExec({
   workerId,
   workerApiConfig,
 }: {
+  codexAccessToken?: string;
   imagePaths?: string[];
   mcpConfig?: {
     gatewayUrl: string;
@@ -216,6 +218,7 @@ export async function streamCodexExec({
   return streamSandboxCommand(
     sandbox,
     createCodexExecCommand({
+      codexAccessToken,
       imagePaths,
       mcpConfig,
       model,
@@ -279,6 +282,7 @@ export function getSandboxStreamChunkText(chunk: SandboxStreamChunk) {
 }
 
 function createCodexExecCommand({
+  codexAccessToken,
   imagePaths = [],
   mcpConfig,
   model,
@@ -291,6 +295,7 @@ function createCodexExecCommand({
   workerId,
   workerApiConfig,
 }: {
+  codexAccessToken?: string;
   imagePaths?: string[];
   mcpConfig?: {
     gatewayUrl: string;
@@ -319,6 +324,9 @@ function createCodexExecCommand({
   const codexReasoningLevel = normalizeWorkerReasoningLevel(reasoningLevel);
   const codexSpeed = normalizeWorkerSpeed({ model: codexModel, speed });
   const secretEnv = createSecretsEnv(secrets);
+  const codexAccessTokenEnv = codexAccessToken
+    ? `export CODEX_ACCESS_TOKEN=${shellQuote(codexAccessToken)}`
+    : "";
   const mcpEnv = mcpConfig
     ? `export FACTORY_MCP_WORKER_TOKEN=${shellQuote(mcpConfig.token)}`
     : "";
@@ -380,7 +388,7 @@ function createCodexExecCommand({
     secretEnv
       ? `printf %s ${shellQuote(secretEnv)} > ${shellQuote(secretsPath)} && chmod 600 ${shellQuote(secretsPath)}`
       : `rm -f ${shellQuote(secretsPath)}`,
-    `setsid /bin/bash -lc ${shellQuote(`${createCodexPathExport()} ${secretEnv ? `. ${shellQuote(secretsPath)} && ` : ""}${workerApiEnv ? `${workerApiEnv} && ` : ""}${mcpEnv ? `${mcpEnv} && ` : ""}cd ${shellQuote(sandboxWorkspace)} && ${codexCommand} < ${shellQuote(promptPath)}`)} &`,
+    `setsid /bin/bash -lc ${shellQuote(`${createCodexPathExport()} ${secretEnv ? `. ${shellQuote(secretsPath)} && ` : ""}${codexAccessTokenEnv ? `${codexAccessTokenEnv} && ` : ""}${workerApiEnv ? `${workerApiEnv} && ` : ""}${mcpEnv ? `${mcpEnv} && ` : ""}cd ${shellQuote(sandboxWorkspace)} && ${codexCommand} < ${shellQuote(promptPath)}`)} &`,
     "pid=$!",
     `echo "$pid" > ${shellQuote(pidPath)}`,
     'wait "$pid"',


### PR DESCRIPTION
## Summary
- switch new factory and add-agent flows from pasted Codex auth JSON to Codex access tokens
- pass encrypted access tokens to worker runs through CODEX_ACCESS_TOKEN
- add an agent token update endpoint and agents-page token rotation form
- keep legacy auth.json fallback for existing agents while they migrate

## Verification
- pnpm check
- pnpm typecheck