### PR TITLE
Allow factory agents to be deleted

### DIFF
--- a/apps/app/app/factory/[factoryId]/settings/_components/FactorySettingsSectionPage.tsx
+++ b/apps/app/app/factory/[factoryId]/settings/_components/FactorySettingsSectionPage.tsx
@@ -189,6 +189,8 @@ function FactorySettingsPageContent({
   const [billingError, setBillingError] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [agentError, setAgentError] = useState<string | null>(null);
+  const [deletingAgentId, setDeletingAgentId] = useState<string | null>(null);
   const lastSavedNameRef = useRef("");
   const factoryNameId = useId();
 
@@ -304,6 +306,32 @@ function FactorySettingsPageContent({
           : "Factory could not be deleted.",
       );
       setIsDeleting(false);
+    }
+  }
+
+  async function deleteAgent(agent: AgentRecord) {
+    const confirmed = window.confirm(
+      `Delete ${formatAgentType(agent.type)} "${agent.id}"? This permanently removes the agent from this factory.`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    setDeletingAgentId(agent.id);
+    setAgentError(null);
+
+    try {
+      await instantDb.transact(instantDb.tx.agents[agent.id].delete());
+    } catch (deleteAgentError) {
+      console.error(deleteAgentError);
+      setAgentError(
+        deleteAgentError instanceof Error
+          ? deleteAgentError.message
+          : "Agent could not be deleted.",
+      );
+    } finally {
+      setDeletingAgentId(null);
     }
   }
 
@@ -478,9 +506,12 @@ function FactorySettingsPageContent({
         <FactoryAgentsPanel
           agents={agents}
           canManageAgents={canManageAgents}
+          deletingAgentId={deletingAgentId}
+          error={agentError}
           factoryId={factoryId}
           instantDb={instantDb}
           isLoading={isLoading}
+          onDeleteAgent={deleteAgent}
         />
       ) : null}
 
@@ -593,15 +624,21 @@ function FactorySettingsPageContent({
 function FactoryAgentsPanel({
   agents,
   canManageAgents,
+  deletingAgentId,
+  error,
   factoryId,
   instantDb,
   isLoading,
+  onDeleteAgent,
 }: {
   agents: AgentRecord[];
   canManageAgents: boolean;
+  deletingAgentId: string | null;
+  error: string | null;
   factoryId: string;
   instantDb: AppDb;
   isLoading: boolean;
+  onDeleteAgent: (agent: AgentRecord) => void;
 }) {
   return (
     <FactorySectionCard>
@@ -614,6 +651,11 @@ function FactoryAgentsPanel({
           </p>
         )}
 
+        {error ? (
+          <p className="text-red-11 text-sm" role="alert">
+            {error}
+          </p>
+        ) : null}
         {isLoading ? (
           <p className="text-grayscale-10 text-sm">Loading agents...</p>
         ) : agents.length > 0 ? (
@@ -663,6 +705,18 @@ function FactoryAgentsPanel({
                         ? "Unauthenticated"
                         : "Connected"}
                     </span>
+                    {canManageAgents ? (
+                      <button
+                        aria-label={`Delete ${getAgentDisplayName(agent)} agent`}
+                        className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-grayscale-4 text-grayscale-10 transition-colors hover:border-red-7 hover:bg-red-2 hover:text-red-11 disabled:cursor-not-allowed disabled:opacity-60"
+                        disabled={deletingAgentId === agent.id}
+                        onClick={() => onDeleteAgent(agent)}
+                        title="Delete agent"
+                        type="button"
+                      >
+                        <TrashIcon aria-hidden="true" size={14} weight="bold" />
+                      </button>
+                    ) : null}
                   </div>
                 </div>
                 <AgentIdentityOptions

--- a/apps/app/instant.perms.ts
+++ b/apps/app/instant.perms.ts
@@ -95,7 +95,7 @@ const rules = {
       view: "isFactoryMember",
       create: "false",
       update: "isFactoryMember && onlyUpdatesAgentSettings",
-      delete: "false",
+      delete: "isFactoryMember",
     },
     fields: {
       authEncrypted: "false",

--- a/tests/unit/auth-permissions.test.ts
+++ b/tests/unit/auth-permissions.test.ts
@@ -28,8 +28,8 @@ test("factory access allows owners and active supervisors only", () => {
 
 test("permissions keep sensitive server-owned records private", () => {
   assert.match(permissionsSource, /valueEncrypted:\s+"false"/);
-  assert.match(permissionsSource, /authEncrypted:\s+"false"/);
   assert.match(permissionsSource, /tokenEncrypted:\s+"false"/);
+  assert.match(permissionsSource, /authEncrypted:\s+"false"/);
   assert.match(
     permissionsSource,
     /factoryStripeBillings:[\s\S]*?view:\s+"false"/,
@@ -46,6 +46,11 @@ test("permissions keep sensitive server-owned records private", () => {
     permissionsSource,
     /factoryMcpWorkerTokens:[\s\S]*?view:\s+"false"/,
   );
+});
+
+test("agent permissions allow factory members to delete agents without client creation", () => {
+  assert.match(permissionsSource, /agents:[\s\S]*?create:\s+"false"/);
+  assert.match(permissionsSource, /agents:[\s\S]*?delete:\s+"isFactoryMember"/);
 });
 
 test("permissions prevent direct creation of server-owned integrations", () => {


### PR DESCRIPTION
## Summary
- Add an agent delete action to the factory Agents settings panel.
- Permit factory members to delete agent records in Instant permissions while keeping `authEncrypted` hidden from client reads.
- Add permission test coverage for agent deletion.

## Verification
- `npx pnpm install --frozen-lockfile` passed.
- `npx pnpm check` passed.
- `npx pnpm typecheck` passed.
- `npx pnpm test:unit` passed.