### PR TITLE
Update homepage positioning copy

### DIFF
--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -26,7 +26,8 @@ const pirataOne = Pirata_One({
 
 export const metadata: Metadata = {
   title: "Factory",
-  description: "A Next.js starter using Chord UI, InstantDB, and Trigger.dev",
+  description:
+    "Open source, collaborative software factory running in the cloud using your existing codex agents.",
   applicationName: "FactoryPlane",
   manifest: "/manifest.webmanifest",
   appleWebApp: {

--- a/apps/website/app/manifest.ts
+++ b/apps/website/app/manifest.ts
@@ -4,7 +4,8 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "FactoryPlane",
     short_name: "FactoryPlane",
-    description: "Cloud software factory using your existing coding agents.",
+    description:
+      "Open source, collaborative software factory running in the cloud using your existing codex agents.",
     start_url: "/",
     scope: "/",
     display: "standalone",

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -77,14 +77,18 @@ export default function Home() {
           </div>
           <p className="max-w-lg text-balance text-lg font-medium leading-6 text-grayscale-12 mt-8">
             Open source, collaborative software factory running in the cloud
-            using your existing coding agents.
+            using your existing codex agents.
           </p>
           <p className="max-w-lg text-balance text-sm leading-6 text-grayscale-11 mt-1">
             Spin up workers in the cloud, invite supervisors, and steer the work
             together — all from one place.
           </p>
           <div className="mt-4 flex flex-row flex-wrap items-center gap-2">
-            <Button className="text-xs" href="https://app.factoryplane.com/factories" variant="primary">
+            <Button
+              className="text-xs"
+              href="https://app.factoryplane.com/factories"
+              variant="primary"
+            >
               <RocketLaunchIcon size={16} weight="bold" />
               Get Started
             </Button>


### PR DESCRIPTION
## Summary
- Update the website hero copy to mention existing codex agents
- Align the app metadata and website PWA manifest description with the homepage positioning
- Rebase onto the current monorepo layout and apply the repo formatter to touched files

## Validation
- `npx -y pnpm@11.1.3 exec biome check apps/website/app/page.tsx apps/app/app/layout.tsx apps/website/app/manifest.ts`
- `npx -y pnpm@11.1.3 typecheck`
- `git diff --check -- apps/website/app/page.tsx apps/app/app/layout.tsx apps/website/app/manifest.ts`