### PR TITLE
Add worker activity messages

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,10 @@ _Avoid_: bot, assistant
 An execution thread that belongs to a Factory and owns one persistent sandbox.
 _Avoid_: run, job
 
+**Worker Activity Message**:
+A short description of the work a supervisor should associate with a Worker. It may describe the current or most recent work focus; Worker Status determines whether the Worker is actively running.
+_Avoid_: worker name, title, status message
+
 **Worker Status**:
 The execution readiness state of a Worker.
 _Avoid_: job status
@@ -62,7 +66,8 @@ _Avoid_: worker, run
 - A **Factory** has zero or more **Agents**.
 - A **Factory** has zero or more **Workers**.
 - A **Worker** owns exactly one persistent sandbox.
-- A **Worker Status** is one of `queued`, `running`, `idle`, or `failed`.
+- A **Worker** has zero or one **Worker Activity Message**.
+- A **Worker Status** is one of `queued`, `running`, `idle`, `failed`, or `retired`.
 - A **Worker** has zero or one **Codex Session** until the first Codex exec run reports its session id.
 - A **Worker** has zero or one **Active Codex Process** while Codex exec is running.
 - A **Worker** has zero or one **Active Command** to prevent interrupted Codex exec tasks from overwriting a newer prompt.

--- a/apps/app/app/factory/[factoryId]/layout.tsx
+++ b/apps/app/app/factory/[factoryId]/layout.tsx
@@ -38,6 +38,7 @@ import { cn } from "@/helpers/classname-helper";
 import type { FactoryColorValue } from "@/helpers/factory-colors";
 import type { UserAvatarColorValue } from "@/helpers/user-avatar-colors";
 import { getUserDisplayName } from "@/helpers/user-identity";
+import { getWorkerFallbackName } from "@/helpers/worker-activity";
 import { getWorkerStatusTone } from "@/helpers/worker-status";
 import type { AppDb } from "@/lib/db.client";
 import { db } from "@/lib/db.client";
@@ -52,6 +53,7 @@ type FactoryRecord = {
 };
 
 type WorkerRecord = {
+  activityMessage?: string;
   createdAt?: string;
   id: string;
   name?: string;
@@ -784,6 +786,14 @@ function WorkerSidebarLink({
 }) {
   const href = `/factory/${factoryId}/workers/${worker.id}`;
   const statusTone = getWorkerStatusTone(worker.status);
+  const workerName = getWorkerFallbackName(worker);
+  const activityMessage = worker.activityMessage?.trim();
+  const createdAtLabel = DateTime.fromISO(worker.createdAt ?? "").toRelative();
+  const secondaryLabel = activityMessage
+    ? createdAtLabel
+      ? `${workerName} · ${createdAtLabel}`
+      : workerName
+    : createdAtLabel;
 
   return (
     <Link
@@ -797,11 +807,13 @@ function WorkerSidebarLink({
       <span className="flex min-w-0 items-start gap-2">
         <span className="min-w-0 flex-1">
           <span className="block truncate">
-            {worker.name ?? `Worker ${worker.id.slice(0, 8)}`}
+            {activityMessage || workerName}
           </span>
-          <span className="block truncate text-grayscale-10 text-xs">
-            {DateTime.fromISO(worker.createdAt ?? "").toRelative()}
-          </span>
+          {secondaryLabel ? (
+            <span className="block truncate text-grayscale-10 text-xs">
+              {secondaryLabel}
+            </span>
+          ) : null}
         </span>
         <WorkerSupervisorPresenceStack supervisors={supervisors} />
         {statusTone.isSpinner ? (

--- a/apps/app/app/factory/[factoryId]/worker-message-client.ts
+++ b/apps/app/app/factory/[factoryId]/worker-message-client.ts
@@ -4,6 +4,7 @@ import { faker } from "@faker-js/faker";
 import { id } from "@instantdb/react";
 import type { ImageAttachment } from "@/components/factory/WorkerComposer";
 import { createSupervisorMessageSender } from "@/helpers/user-identity";
+import { defaultWorkerActivityMessage } from "@/helpers/worker-activity";
 import {
   normalizeWorkerModel,
   normalizeWorkerReasoningLevel,
@@ -118,6 +119,7 @@ export async function triggerWorkerRun({
         updatedAt: now,
         ...(isNewWorker
           ? {
+              activityMessage: defaultWorkerActivityMessage,
               createdAt: now,
               name: faker.person.firstName(),
             }

--- a/apps/app/app/factory/[factoryId]/worker-run-form.tsx
+++ b/apps/app/app/factory/[factoryId]/worker-run-form.tsx
@@ -39,6 +39,7 @@ import { queueWorkerMessage, triggerWorkerRun } from "./worker-message-client";
 
 export type WorkerRecord = {
   activePid?: number;
+  activityMessage?: string;
   agent?: WorkerAgentRecord;
   codexSessionId?: string;
   codexModel?: string;

--- a/apps/app/components/events/event-utils.ts
+++ b/apps/app/components/events/event-utils.ts
@@ -88,11 +88,17 @@ export function getMcpConnectionRequest(data: unknown) {
 }
 
 export function getCodexAgentMessageText(data: unknown) {
+  const structuredResponseText = getWorkerStructuredResponseText(data);
+
+  if (structuredResponseText) {
+    return structuredResponseText;
+  }
+
   if (isRecord(data) && isAssistantLikeMessage(data)) {
     const directText = getTextValue(data);
 
     if (directText) {
-      return directText;
+      return getWorkerStructuredResponseText(directText) ?? directText;
     }
   }
 
@@ -102,7 +108,9 @@ export function getCodexAgentMessageText(data: unknown) {
     .filter(Boolean)
     .join("\n\n");
 
-  return messageText || null;
+  return messageText
+    ? (getWorkerStructuredResponseText(messageText) ?? messageText)
+    : null;
 }
 
 export function getDiagnosticMessage(data: unknown) {
@@ -206,6 +214,14 @@ function getMessageItems(data: unknown) {
     return [data.message];
   }
 
+  if (
+    isRecord(data) &&
+    isRecord(data.msg) &&
+    isAssistantLikeMessage(data.msg)
+  ) {
+    return [data.msg];
+  }
+
   if (isRecord(data) && Array.isArray(data.items)) {
     return data.items.filter(
       (item): item is Record<string, unknown> =>
@@ -284,6 +300,24 @@ function isCodexJsonEvent(event: EventRecord) {
   return (
     event.source === "codex" && getCodexAgentMessageText(event.data) === null
   );
+}
+
+function getWorkerStructuredResponseText(value: unknown) {
+  const parsedValue = typeof value === "string" ? parseJson(value) : value;
+
+  if (!isRecord(parsedValue) || typeof parsedValue.response !== "string") {
+    return null;
+  }
+
+  return parsedValue.response;
+}
+
+function parseJson(value: string) {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
 }
 
 function getPayloadType(data: unknown): string | null {

--- a/apps/app/helpers/worker-activity.ts
+++ b/apps/app/helpers/worker-activity.ts
@@ -1,0 +1,10 @@
+export const defaultWorkerActivityMessage = "Getting onboarded...";
+
+export function getWorkerFallbackName(worker: {
+  id: string;
+  name?: null | string;
+}) {
+  const name = worker.name?.trim();
+
+  return name || `Worker ${worker.id.slice(0, 8)}`;
+}

--- a/apps/app/instant.perms.ts
+++ b/apps/app/instant.perms.ts
@@ -135,7 +135,7 @@ const rules = {
       isFactoryMember:
         "auth.id in data.ref('factory.owner.id') || auth.id in data.ref('factory.supervisors.user.id')",
       onlyCreatesClientWorker:
-        "request.modifiedFields.all(field, field in ['agent', 'codexModel', 'codexReasoningLevel', 'codexSpeed', 'createdAt', 'factory', 'name', 'retiredAt', 'status', 'updatedAt']) && data.status == 'queued' && data.retiredAt == null && codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported",
+        "request.modifiedFields.all(field, field in ['activityMessage', 'agent', 'codexModel', 'codexReasoningLevel', 'codexSpeed', 'createdAt', 'factory', 'name', 'retiredAt', 'status', 'updatedAt']) && data.status == 'queued' && data.retiredAt == null && codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported",
       onlyQueuesClientWorker:
         "request.modifiedFields.all(field, field in ['codexModel', 'codexReasoningLevel', 'codexSpeed', 'retiredAt', 'status', 'updatedAt']) && newData.retiredAt == null && newData.status in ['queued', 'running'] && codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported",
       onlyRetiresClientWorker:

--- a/apps/app/instant.schema.ts
+++ b/apps/app/instant.schema.ts
@@ -71,6 +71,7 @@ const _schema = i.schema({
     workers: i.entity({
       activeCommandId: i.string().indexed().optional(),
       activePid: i.number().optional(),
+      activityMessage: i.string().optional(),
       codexSessionId: i.string().indexed().optional(),
       codexModel: i.string().indexed().optional(),
       codexReasoningLevel: i.string().indexed().optional(),

--- a/apps/app/jobs/run-worker.ts
+++ b/apps/app/jobs/run-worker.ts
@@ -20,6 +20,7 @@ import {
   normalizeWorkerReasoningLevel,
   normalizeWorkerSpeed,
 } from "@/lib/codex/worker-options";
+import { getWorkerStructuredResponse } from "@/lib/codex/worker-response";
 import { decryptSecretValue, encryptSecretValue } from "@/lib/crypto.server";
 import { getAdminDb } from "@/lib/db.server";
 import {
@@ -50,6 +51,7 @@ type RunWorkerPayload = {
 type WorkerRecord = {
   activeCommandId?: string;
   activePid?: number;
+  activityMessage?: string;
   agent?: AgentRecord;
   codexSessionId?: string;
   codexModel?: string;
@@ -863,15 +865,26 @@ async function persistCodexLine(
   }
 
   const sessionId = findCodexSessionId(data);
+  const structuredResponse = getWorkerStructuredResponse(data);
+  const workerUpdates: {
+    activityMessage?: string;
+    codexSessionId?: string;
+    updatedAt: string;
+  } = {
+    updatedAt: new Date().toISOString(),
+  };
 
   if (sessionId) {
+    workerUpdates.codexSessionId = sessionId;
+  }
+
+  if (structuredResponse?.newActivityMessage) {
+    workerUpdates.activityMessage = structuredResponse.newActivityMessage;
+  }
+
+  if (workerUpdates.codexSessionId || workerUpdates.activityMessage) {
     const db = getAdminDb();
-    await db.transact(
-      db.tx.workers[workerId].update({
-        codexSessionId: sessionId,
-        updatedAt: new Date().toISOString(),
-      }),
-    );
+    await db.transact(db.tx.workers[workerId].update(workerUpdates));
   }
 
   return false;

--- a/apps/app/lib/codex/sandbox-auth.ts
+++ b/apps/app/lib/codex/sandbox-auth.ts
@@ -1,3 +1,4 @@
+import { workerStructuredResponseSchema } from "@/lib/codex/worker-response";
 import {
   type AppSandbox,
   createCheckpoint,
@@ -340,7 +341,11 @@ function createCodexExecCommand({
   const promptPath = `${workerDir}/prompt.txt`;
   const authWatcherPath = `${workerDir}/codex-auth-watcher.mjs`;
   const authWatcherLogPath = `${workerDir}/codex-auth-watcher.log`;
-  const workerPrompt = `${factoryWorkerInstructions}\n\nUser task:\n${prompt}`;
+  const responseSchemaPath = `${workerDir}/response-schema.json`;
+  const responseInstructions = resume
+    ? "Your final response must match the configured JSON schema. Put the markdown response for the supervisor in `response`. Set `newActivityMessage` to a concise Worker Activity Message only when the work focus changed; otherwise set it to null."
+    : "Your final response must match the configured JSON schema. Put the markdown response for the supervisor in `response`. Because this is the first Codex run for this Worker, set `newActivityMessage` to a concise Worker Activity Message that describes the work focus.";
+  const workerPrompt = `${factoryWorkerInstructions}\n\n${responseInstructions}\n\nUser task:\n${prompt}`;
   const secretsPath = `${factoryDir}/secrets.env`;
   const codexModel = normalizeWorkerModel(model);
   const codexReasoningLevel = normalizeWorkerReasoningLevel(reasoningLevel);
@@ -373,7 +378,10 @@ function createCodexExecCommand({
   const reasoningLevelArgs = createCodexReasoningLevelArgs(codexReasoningLevel);
   const codexCommand = resume
     ? [
-        "codex exec resume",
+        "codex exec",
+        "--output-schema",
+        shellQuote(responseSchemaPath),
+        "resume",
         sessionId ? shellQuote(sessionId) : "--last",
         "--model",
         shellQuote(codexModel),
@@ -388,6 +396,8 @@ function createCodexExecCommand({
       ].join(" ")
     : [
         "codex exec",
+        "--output-schema",
+        shellQuote(responseSchemaPath),
         "--model",
         shellQuote(codexModel),
         reasoningLevelArgs,
@@ -421,6 +431,7 @@ function createCodexExecCommand({
     `rm -f ${shellQuote(pidPath)}`,
     authWatcherSetup,
     `printf %s ${shellQuote(workerPrompt)} > ${shellQuote(promptPath)}`,
+    `printf %s ${shellQuote(JSON.stringify(workerStructuredResponseSchema))} > ${shellQuote(responseSchemaPath)}`,
     secretEnv
       ? `printf %s ${shellQuote(secretEnv)} > ${shellQuote(secretsPath)} && chmod 600 ${shellQuote(secretsPath)}`
       : `rm -f ${shellQuote(secretsPath)}`,

--- a/apps/app/lib/codex/worker-response.ts
+++ b/apps/app/lib/codex/worker-response.ts
@@ -1,0 +1,200 @@
+export type WorkerStructuredResponse = {
+  newActivityMessage?: null | string;
+  response: string;
+};
+
+export const workerStructuredResponseSchema = {
+  additionalProperties: false,
+  properties: {
+    newActivityMessage: {
+      description:
+        "A short replacement Worker Activity Message, or null when the existing activity message should stay unchanged.",
+      maxLength: 120,
+      type: ["string", "null"],
+    },
+    response: {
+      description: "The markdown response to show to the supervisor.",
+      type: "string",
+    },
+  },
+  required: ["response", "newActivityMessage"],
+  type: "object",
+} as const;
+
+export function getWorkerStructuredResponse(
+  value: unknown,
+): null | WorkerStructuredResponse {
+  const directResponse = parseWorkerStructuredResponse(value);
+
+  if (directResponse) {
+    return directResponse;
+  }
+
+  const messageText = getCodexAgentMessageText(value);
+
+  if (!messageText) {
+    return null;
+  }
+
+  return parseWorkerStructuredResponse(parseJson(messageText));
+}
+
+function parseWorkerStructuredResponse(
+  value: unknown,
+): null | WorkerStructuredResponse {
+  if (!isRecord(value) || typeof value.response !== "string") {
+    return null;
+  }
+
+  const newActivityMessage =
+    typeof value.newActivityMessage === "string"
+      ? value.newActivityMessage.trim()
+      : null;
+
+  return {
+    newActivityMessage: newActivityMessage || null,
+    response: value.response,
+  };
+}
+
+function getCodexAgentMessageText(data: unknown) {
+  if (isRecord(data) && isAssistantLikeMessage(data)) {
+    const directText = getTextValue(data);
+
+    if (directText) {
+      return directText;
+    }
+  }
+
+  const messageItems = getMessageItems(data);
+  const messageText = messageItems
+    .map((item) => getTextValue(item))
+    .filter(Boolean)
+    .join("\n\n");
+
+  return messageText || null;
+}
+
+function getMessageItems(data: unknown) {
+  if (
+    isRecord(data) &&
+    isRecord(data.item) &&
+    isAssistantLikeMessage(data.item)
+  ) {
+    return [data.item];
+  }
+
+  if (
+    isRecord(data) &&
+    isRecord(data.message) &&
+    isAssistantLikeMessage(data.message)
+  ) {
+    return [data.message];
+  }
+
+  if (
+    isRecord(data) &&
+    isRecord(data.msg) &&
+    isAssistantLikeMessage(data.msg)
+  ) {
+    return [data.msg];
+  }
+
+  if (isRecord(data) && Array.isArray(data.items)) {
+    return data.items.filter(
+      (item): item is Record<string, unknown> =>
+        isRecord(item) && isAssistantLikeMessage(item),
+    );
+  }
+
+  if (isRecord(data) && Array.isArray(data.output)) {
+    return data.output.filter(
+      (item): item is Record<string, unknown> =>
+        isRecord(item) && isAssistantLikeMessage(item),
+    );
+  }
+
+  return [];
+}
+
+function getTextValue(item: Record<string, unknown>): string | null {
+  if (typeof item.text === "string") {
+    return item.text;
+  }
+
+  if (typeof item.message === "string") {
+    return item.message;
+  }
+
+  if (isRecord(item.message)) {
+    const messageText = getTextValue(item.message);
+
+    if (messageText) {
+      return messageText;
+    }
+  }
+
+  if (typeof item.content === "string") {
+    return item.content;
+  }
+
+  if (isRecord(item.content)) {
+    const contentText = getTextValue(item.content);
+
+    if (contentText) {
+      return contentText;
+    }
+  }
+
+  if (Array.isArray(item.content)) {
+    return item.content
+      .map((part) => {
+        if (!isRecord(part)) {
+          return null;
+        }
+
+        if (typeof part.text === "string") {
+          return part.text;
+        }
+
+        if (typeof part.output_text === "string") {
+          return part.output_text;
+        }
+
+        if (typeof part.content === "string") {
+          return part.content;
+        }
+
+        return null;
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  return null;
+}
+
+function isAssistantLikeMessage(item: Record<string, unknown>) {
+  const type = typeof item.type === "string" ? item.type : "";
+  const role = typeof item.role === "string" ? item.role : "";
+
+  return (
+    role === "assistant" ||
+    type === "agent_message" ||
+    type === "assistant_message" ||
+    (type === "message" && !role) ||
+    type === "response.output_text"
+  );
+}
+
+function parseJson(value: string) {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/tests/unit/auth-permissions.test.ts
+++ b/tests/unit/auth-permissions.test.ts
@@ -108,7 +108,7 @@ test("permissions let factory members read and act on capability records", () =>
 test("worker permissions keep server-owned runtime fields out of client writes", () => {
   assert.match(
     permissionsSource,
-    /onlyCreatesClientWorker:[\s\S]*?\['agent', 'codexModel', 'codexReasoningLevel', 'codexSpeed', 'createdAt', 'factory', 'name', 'retiredAt', 'status', 'updatedAt'\][\s\S]*?codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported/,
+    /onlyCreatesClientWorker:[\s\S]*?\['activityMessage', 'agent', 'codexModel', 'codexReasoningLevel', 'codexSpeed', 'createdAt', 'factory', 'name', 'retiredAt', 'status', 'updatedAt'\][\s\S]*?codexModelIsSupported && codexReasoningLevelIsSupported && codexSpeedIsSupported/,
   );
   assert.match(
     permissionsSource,

--- a/tests/unit/event-utils.test.ts
+++ b/tests/unit/event-utils.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  getCodexAgentMessageText,
   getEventFeedItems,
   getEventSender,
 } from "../../apps/app/components/events/event-utils.ts";
@@ -43,5 +44,25 @@ test("event sender reads supervisor snapshots", () => {
       id: "user-1",
       name: "ruthie",
     },
+  );
+});
+
+test("Codex event text unwraps worker structured responses", () => {
+  assert.equal(
+    getCodexAgentMessageText({
+      item: {
+        content: [
+          {
+            text: JSON.stringify({
+              newActivityMessage: "Reviewing permissions",
+              response: "I found one issue.",
+            }),
+          },
+        ],
+        role: "assistant",
+        type: "message",
+      },
+    }),
+    "I found one issue.",
   );
 });

--- a/tests/unit/worker-response.test.ts
+++ b/tests/unit/worker-response.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getWorkerStructuredResponse,
+  workerStructuredResponseSchema,
+} from "../../apps/app/lib/codex/worker-response.ts";
+
+test("worker structured responses are parsed from direct schema output", () => {
+  assert.deepEqual(
+    getWorkerStructuredResponse({
+      newActivityMessage: "Fixing sidebar labels",
+      response: "Done.",
+    }),
+    {
+      newActivityMessage: "Fixing sidebar labels",
+      response: "Done.",
+    },
+  );
+});
+
+test("worker structured responses are parsed from Codex assistant text", () => {
+  assert.deepEqual(
+    getWorkerStructuredResponse({
+      item: {
+        content: [
+          {
+            text: JSON.stringify({
+              newActivityMessage: null,
+              response: "Still working through this.",
+            }),
+          },
+        ],
+        role: "assistant",
+        type: "message",
+      },
+    }),
+    {
+      newActivityMessage: null,
+      response: "Still working through this.",
+    },
+  );
+});
+
+test("worker structured response schema requires activity and response fields", () => {
+  assert.deepEqual(workerStructuredResponseSchema.required, [
+    "response",
+    "newActivityMessage",
+  ]);
+});


### PR DESCRIPTION
## Summary
- add Worker Activity Message domain docs, schema field, and default onboarding activity
- show activity message as the worker sidebar primary label with worker name underneath
- require structured Codex final responses with `response` and `newActivityMessage`, then persist activity updates and unwrap markdown for the event feed

## Verification
- `npx --yes pnpm@11.1.3 test:unit`
- `npx --yes pnpm@11.1.3 typecheck`
- `npx --yes pnpm@11.1.3 exec biome check CONTEXT.md apps/app/instant.schema.ts apps/app/instant.perms.ts apps/app/app/factory/[factoryId]/worker-message-client.ts apps/app/app/factory/[factoryId]/worker-run-form.tsx apps/app/app/factory/[factoryId]/layout.tsx apps/app/components/events/event-utils.ts apps/app/helpers/worker-activity.ts apps/app/lib/codex/sandbox-auth.ts apps/app/lib/codex/worker-response.ts apps/app/jobs/run-worker.ts tests/unit/auth-permissions.test.ts tests/unit/event-utils.test.ts tests/unit/worker-response.test.ts