### PR TITLE
Fix worker activity sidebar fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
           run_install: false
 
       - name: Setup Node
@@ -124,7 +123,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
           run_install: false
 
       - name: Setup Node

--- a/apps/app/app/factory/[factoryId]/layout.tsx
+++ b/apps/app/app/factory/[factoryId]/layout.tsx
@@ -38,7 +38,10 @@ import { cn } from "@/helpers/classname-helper";
 import type { FactoryColorValue } from "@/helpers/factory-colors";
 import type { UserAvatarColorValue } from "@/helpers/user-avatar-colors";
 import { getUserDisplayName } from "@/helpers/user-identity";
-import { getWorkerFallbackName } from "@/helpers/worker-activity";
+import {
+  getWorkerActivityMessage,
+  getWorkerFallbackName,
+} from "@/helpers/worker-activity";
 import { getWorkerStatusTone } from "@/helpers/worker-status";
 import type { AppDb } from "@/lib/db.client";
 import { db } from "@/lib/db.client";
@@ -787,13 +790,11 @@ function WorkerSidebarLink({
   const href = `/factory/${factoryId}/workers/${worker.id}`;
   const statusTone = getWorkerStatusTone(worker.status);
   const workerName = getWorkerFallbackName(worker);
-  const activityMessage = worker.activityMessage?.trim();
+  const activityMessage = getWorkerActivityMessage(worker);
   const createdAtLabel = DateTime.fromISO(worker.createdAt ?? "").toRelative();
-  const secondaryLabel = activityMessage
-    ? createdAtLabel
-      ? `${workerName} · ${createdAtLabel}`
-      : workerName
-    : createdAtLabel;
+  const secondaryLabel = createdAtLabel
+    ? `${workerName} · ${createdAtLabel}`
+    : workerName;
 
   return (
     <Link
@@ -806,9 +807,7 @@ function WorkerSidebarLink({
     >
       <span className="flex min-w-0 items-start gap-2">
         <span className="min-w-0 flex-1">
-          <span className="block truncate">
-            {activityMessage || workerName}
-          </span>
+          <span className="block truncate">{activityMessage}</span>
           {secondaryLabel ? (
             <span className="block truncate text-grayscale-10 text-xs">
               {secondaryLabel}

--- a/apps/app/helpers/worker-activity.ts
+++ b/apps/app/helpers/worker-activity.ts
@@ -1,5 +1,11 @@
 export const defaultWorkerActivityMessage = "Getting onboarded...";
 
+export function getWorkerActivityMessage(worker: {
+  activityMessage?: null | string;
+}) {
+  return worker.activityMessage?.trim() || defaultWorkerActivityMessage;
+}
+
 export function getWorkerFallbackName(worker: {
   id: string;
   name?: null | string;

--- a/tests/unit/worker-activity.test.ts
+++ b/tests/unit/worker-activity.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  defaultWorkerActivityMessage,
+  getWorkerActivityMessage,
+  getWorkerFallbackName,
+} from "../../apps/app/helpers/worker-activity.ts";
+
+test("worker activity falls back to the default onboarding message", () => {
+  assert.equal(getWorkerActivityMessage({}), defaultWorkerActivityMessage);
+  assert.equal(
+    getWorkerActivityMessage({ activityMessage: "   " }),
+    defaultWorkerActivityMessage,
+  );
+});
+
+test("worker activity trims persisted messages", () => {
+  assert.equal(
+    getWorkerActivityMessage({ activityMessage: "  Reviewing logs  " }),
+    "Reviewing logs",
+  );
+});
+
+test("worker fallback name prefers a trimmed worker name", () => {
+  assert.equal(
+    getWorkerFallbackName({ id: "worker-123456789", name: "  Ruth  " }),
+    "Ruth",
+  );
+  assert.equal(
+    getWorkerFallbackName({ id: "worker-123456789", name: "   " }),
+    "Worker worker-1",
+  );
+});


### PR DESCRIPTION
## Summary
- Show the default Worker Activity Message when existing workers have no persisted activity message
- Keep the worker name visible as the secondary sidebar text
- Remove the conflicting pnpm version pin from the deploy workflow so it uses package.json as the source of truth

## Verification
- `npx --yes pnpm@11.1.3 exec biome check .github/workflows/deploy.yml apps/app/helpers/worker-activity.ts 'apps/app/app/factory/[factoryId]/layout.tsx' tests/unit/worker-activity.test.ts`
- `node --experimental-strip-types --test tests/unit/worker-activity.test.ts`
- `npx --yes pnpm@11.1.3 test:unit`
- `npx --yes pnpm@11.1.3 typecheck`
- `npx --yes pnpm@11.1.3 check`